### PR TITLE
New NATS subject & helm chart fixes

### DIFF
--- a/charts/lfx-v2-access-check/Chart.yaml
+++ b/charts/lfx-v2-access-check/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-access-check
 description: LFX Platform V2 Access Check Service chart
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "0.1.0"

--- a/charts/lfx-v2-access-check/templates/deployment.yaml
+++ b/charts/lfx-v2-access-check/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - name: NATS_URL
               value: "{{ .Values.nats.url }}"
             - name: JWKS_URL
-              value: "{{ .Values.heimdall.url }}"
+              value: "{{ .Values.heimdall.jwks_url }}"
           livenessProbe:
             httpGet:
               path: /livez

--- a/charts/lfx-v2-access-check/templates/ruleset.yaml
+++ b/charts/lfx-v2-access-check/templates/ruleset.yaml
@@ -16,7 +16,7 @@ spec:
         routes:
           - path: /access-check
       execute:
-        - authenticator: anonymous_authenticator
+        - authenticator: oidc
         - authorizer: allow_all
         - finalizer: create_jwt
           config:

--- a/charts/lfx-v2-access-check/values.yaml
+++ b/charts/lfx-v2-access-check/values.yaml
@@ -40,3 +40,4 @@ nats:
 heimdall:
   enabled: true
   url: http://lfx-platform-heimdall.lfx.svc.cluster.local:4456
+  jwks_url: http://lfx-platform-heimdall:4457/.well-known/jwks

--- a/internal/service/access_service_test.go
+++ b/internal/service/access_service_test.go
@@ -143,8 +143,8 @@ func TestCheckAccess_Success(t *testing.T) {
 	authRepo := &mockAuthRepository{}
 	messagingRepo := &mockMessagingRepository{
 		requestFunc: func(_ context.Context, subject string, _ []byte, _ time.Duration) ([]byte, error) {
-			if subject != "dev.lfx.access_check.request" {
-				t.Errorf("Expected subject 'dev.lfx.access_check.request', got '%s'", subject)
+			if subject != "lfx.access_check.request" {
+				t.Errorf("Expected subject 'lfx.access_check.request', got '%s'", subject)
 			}
 			return []byte("allow"), nil
 		},

--- a/pkg/constants/service.go
+++ b/pkg/constants/service.go
@@ -17,7 +17,7 @@ const (
 	ServiceRequestIDKey ContextKey = RequestIDHeader
 
 	// NATS subjects for messaging
-	AccessCheckSubject = "dev.lfx.access_check.request"
+	AccessCheckSubject = "lfx.access_check.request"
 
 	// API version constants
 	SupportedAPIVersion = "1"


### PR DESCRIPTION
This pull request updates the LFX V2 Access Check Service to improve authentication handling, update NATS messaging subject names, and enhance configuration clarity. The most important changes are grouped below.

**Authentication and Authorization Updates:**

* Changed the authenticator in the ruleset from `anonymous_authenticator` to `oidc`, enforcing OIDC-based authentication for access checks.

**Configuration Improvements:**

* Updated the JWKS URL reference in the deployment template to use `heimdall.jwks_url` instead of `heimdall.url`, and added `jwks_url` to the `values.yaml` for more explicit configuration of JWKS endpoint. [[1]](diffhunk://#diff-5568d214279377f29cece53d8057d0e96551965d8b6a8037ea0b99601476a9c5L40-R40) [[2]](diffhunk://#diff-d2bc7ed855db33624a0ca7b96a2560335c814dd6beb46d6687edf68cc47d253eR43)

**Messaging Subject Name Standardization:**

* Renamed the NATS subject for access check requests from `dev.lfx.access_check.request` to `lfx.access_check.request` in both constants and test assertions, ensuring consistency and removing the "dev" prefix. [[1]](diffhunk://#diff-d77a2ab7585e366333e2018d8348a696467c98170aed01f4bd79434d2daab60fL20-R20) [[2]](diffhunk://#diff-743228f8c07724ffe5549d5f38343b408e548a29eda90459b04b09a9d431fef6L146-R147)

**Chart Version Update:**

* Bumped the Helm chart version from `0.2.1` to `0.2.2` to reflect these changes.