### PR TITLE
Update HTTPRoute and RuleSet with missing fields

### DIFF
--- a/charts/lfx-v2-access-check/Chart.yaml
+++ b/charts/lfx-v2-access-check/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-access-check
 description: LFX Platform V2 Access Check Service chart
 type: application
-version: 0.2.3
+version: 0.2.4
 appVersion: "0.1.0"

--- a/charts/lfx-v2-access-check/templates/httproute.yaml
+++ b/charts/lfx-v2-access-check/templates/httproute.yaml
@@ -9,7 +9,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   parentRefs:
-    - name: {{ .Values.traefik.gateway.name }}
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: {{ .Values.traefik.gateway.name }}
       namespace: {{ .Values.traefik.gateway.namespace }}
   hostnames:
     - "lfx-api.{{ .Values.lfx.domain }}"
@@ -33,6 +35,9 @@ spec:
             name: heimdall
       {{- end }}
       backendRefs:
-        - name: lfx-v2-access-check
+        - group: ""
+          kind: Service
+          name: lfx-v2-access-check
           port: {{ .Values.app.port | int }}
+          weight: 1
 {{- end }}

--- a/charts/lfx-v2-access-check/templates/ruleset.yaml
+++ b/charts/lfx-v2-access-check/templates/ruleset.yaml
@@ -10,6 +10,7 @@ metadata:
 spec:
   rules:
     - id: "rule:lfx-v2-access-check:access-check"
+      allow_encoded_slashes: "off"
       match:
         methods:
           - POST
@@ -23,6 +24,7 @@ spec:
             values:
               aud: {{ .Values.app.audience }}
     - id: "rule:lfx-v2-access-check:openapi"
+      allow_encoded_slashes: "off"
       match:
         methods:
           - GET


### PR DESCRIPTION
This pull request updates the Helm chart for the `lfx-v2-access-check` service, focusing on improving compatibility with Kubernetes Gateway APIs and enhancing security settings in the HTTP route and ruleset configurations. The chart version is also incremented to reflect these changes.

**Gateway API compatibility and configuration:**

* Updated `httproute.yaml` to explicitly specify the `group` and `kind` fields for both `parentRefs` (set to `Gateway`) and `backendRefs` (set to `Service`) to ensure compatibility with the Kubernetes Gateway API. Also, added a `weight` field to the backend reference. [[1]](diffhunk://#diff-a680e3783d20286cdaecfc8de270f799c12d5daf4a2ff696712b86ab0ba512f6L12-R14) [[2]](diffhunk://#diff-a680e3783d20286cdaecfc8de270f799c12d5daf4a2ff696712b86ab0ba512f6L36-R42)

**Security and routing rules:**

* Added `allow_encoded_slashes: "off"` to both access-check and openapi rules in `ruleset.yaml` to enhance security by disallowing encoded slashes in request URLs. [[1]](diffhunk://#diff-446d96047a1ed05d9428695e5aa9e7228bdfbc0c7c07081baa294dddd1519367R13) [[2]](diffhunk://#diff-446d96047a1ed05d9428695e5aa9e7228bdfbc0c7c07081baa294dddd1519367R27)

**Chart versioning:**

* Bumped the chart version from `0.2.3` to `0.2.4` in `Chart.yaml` to reflect the new changes.

Issue: LFXV2-511