### PR TITLE
Register docs into backstage with mkdocs file

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,6 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+---
+site_name: LFX Access Check Service
+site_description: Documentation for LFX Access Check Service
+plugins:
+  - techdocs-core


### PR DESCRIPTION
For docs to populate into backstage, an mkdocs.yml file must be present. I'm also just making sure that docs populate correctly with the auto-discovery feature