### PR TITLE
Add deployment annotation for Backstage ingestion

### DIFF
--- a/charts/lfx-v2-access-check/templates/deployment.yaml
+++ b/charts/lfx-v2-access-check/templates/deployment.yaml
@@ -6,6 +6,8 @@ kind: Deployment
 metadata:
   name: lfx-v2-access-check
   namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:


### PR DESCRIPTION
Spotify Backstage can pull kubernetes data from components using deployment annotations. This service is missing the name annotation needed to discover it.