### PR TITLE
feat(chart): add /my-grants HTTPRoute match and Heimdall ruleset

### DIFF
--- a/charts/lfx-v2-access-check/templates/httproute.yaml
+++ b/charts/lfx-v2-access-check/templates/httproute.yaml
@@ -26,6 +26,9 @@ spec:
         - path:
             type: PathPrefix
             value: /_access-check/
+        - path:
+            type: Exact
+            value: /my-grants
       {{- if .Values.heimdall.enabled }}
       filters:
         - type: ExtensionRef

--- a/charts/lfx-v2-access-check/templates/ruleset.yaml
+++ b/charts/lfx-v2-access-check/templates/ruleset.yaml
@@ -23,6 +23,20 @@ spec:
           config:
             values:
               aud: {{ .Values.app.audience }}
+    - id: "rule:lfx-v2-access-check:my-grants"
+      allow_encoded_slashes: "off"
+      match:
+        methods:
+          - GET
+        routes:
+          - path: /my-grants
+      execute:
+        - authenticator: oidc
+        - authorizer: allow_all
+        - finalizer: create_jwt
+          config:
+            values:
+              aud: {{ .Values.app.audience }}
     - id: "rule:lfx-v2-access-check:openapi"
       allow_encoded_slashes: "off"
       match:


### PR DESCRIPTION
## Summary

- Add `GET /my-grants` path match to the Helm chart HTTPRoute so the endpoint is reachable through the gateway
- Add corresponding Heimdall RuleSet rule (`oidc → allow_all → create_jwt`) to authenticate requests to `/my-grants`

The `/my-grants` endpoint was implemented in v0.3.0 but the chart was missing the route and auth rule, making it unreachable in deployed environments.

## Jira

LFXV2-1481

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)