### PR TITLE
feat: exclude health endpoints from tracing

### DIFF
--- a/cmd/lfx-access-check/server.go
+++ b/cmd/lfx-access-check/server.go
@@ -103,7 +103,7 @@ func handleHTTPServer(ctx context.Context, cfg *config.Config, endpoints *access
 		handler = otelhttp.NewHandler(handler, "access-check",
 			otelhttp.WithFilter(func(r *http.Request) bool {
 				p := r.URL.Path
-				return p != "/healthz" && p != "/livez" && p != "/readyz"
+				return p != accesssvcsvr.LivezAccessSvcPath() && p != accesssvcsvr.ReadyzAccessSvcPath()
 			}),
 		)
 	}

--- a/cmd/lfx-access-check/server.go
+++ b/cmd/lfx-access-check/server.go
@@ -100,7 +100,12 @@ func handleHTTPServer(ctx context.Context, cfg *config.Config, endpoints *access
 		}
 
 		// Wrap the handler with OpenTelemetry instrumentation
-		handler = otelhttp.NewHandler(handler, "access-check")
+		handler = otelhttp.NewHandler(handler, "access-check",
+			otelhttp.WithFilter(func(r *http.Request) bool {
+				p := r.URL.Path
+				return p != "/healthz" && p != "/livez" && p != "/readyz"
+			}),
+		)
 	}
 
 	// Create HTTP server


### PR DESCRIPTION
## Summary

- Add `otelhttp.WithFilter` to `otelhttp.NewHandler` to skip span creation for `/healthz`, `/livez`, and `/readyz` Kubernetes probe endpoints
- Reduces high-volume, low-value trace noise from liveness/readiness probes

## Test plan

- [x] `go build ./...` passes

Issue: LFXV2-1583

🤖 Generated with [Claude Code](https://claude.com/claude-code)