### PR TITLE
fix(otel): honor parent span sampling decisions

### DIFF
--- a/charts/lfx-v2-access-check/templates/deployment.yaml
+++ b/charts/lfx-v2-access-check/templates/deployment.yaml
@@ -85,6 +85,15 @@ spec:
             - name: OTEL_TRACES_SAMPLE_RATIO
               value: {{ $otelTracesSampleRatio | quote }}
             {{- end }}
+            {{- $otelTracesSampler := .Values.app.otel.tracesSampler | toString | trim }}
+            {{- if ne $otelTracesSampler "" }}
+            - name: OTEL_TRACES_SAMPLER
+              value: {{ $otelTracesSampler | quote }}
+            {{- if ne $otelTracesSampleRatio "" }}
+            - name: OTEL_TRACES_SAMPLER_ARG
+              value: {{ $otelTracesSampleRatio | quote }}
+            {{- end }}
+            {{- end }}
             {{- $otelMetricsExporter := .Values.app.otel.metricsExporter | toString | trim }}
             {{- if ne $otelMetricsExporter "" }}
             - name: OTEL_METRICS_EXPORTER

--- a/charts/lfx-v2-access-check/templates/deployment.yaml
+++ b/charts/lfx-v2-access-check/templates/deployment.yaml
@@ -80,19 +80,10 @@ spec:
             - name: OTEL_TRACES_EXPORTER
               value: {{ $otelTracesExporter | quote }}
             {{- end }}
-            {{- $otelTracesSampleRatio := .Values.app.otel.tracesSampleRatio | toString | trim }}
-            {{- if ne $otelTracesSampleRatio "" }}
-            - name: OTEL_TRACES_SAMPLE_RATIO
-              value: {{ $otelTracesSampleRatio | quote }}
-            {{- end }}
             {{- $otelTracesSampler := .Values.app.otel.tracesSampler | toString | trim }}
             {{- if ne $otelTracesSampler "" }}
             - name: OTEL_TRACES_SAMPLER
               value: {{ $otelTracesSampler | quote }}
-            {{- if ne $otelTracesSampleRatio "" }}
-            - name: OTEL_TRACES_SAMPLER_ARG
-              value: {{ $otelTracesSampleRatio | quote }}
-            {{- end }}
             {{- end }}
             {{- $otelMetricsExporter := .Values.app.otel.metricsExporter | toString | trim }}
             {{- if ne $otelMetricsExporter "" }}

--- a/charts/lfx-v2-access-check/templates/deployment.yaml
+++ b/charts/lfx-v2-access-check/templates/deployment.yaml
@@ -85,6 +85,11 @@ spec:
             - name: OTEL_TRACES_SAMPLER
               value: {{ $otelTracesSampler | quote }}
             {{- end }}
+            {{- $otelTracesSamplerArg := .Values.app.otel.tracesSamplerArg | toString | trim }}
+            {{- if ne $otelTracesSamplerArg "" }}
+            - name: OTEL_TRACES_SAMPLER_ARG
+              value: {{ $otelTracesSamplerArg | quote }}
+            {{- end }}
             {{- $otelMetricsExporter := .Values.app.otel.metricsExporter | toString | trim }}
             {{- if ne $otelMetricsExporter "" }}
             - name: OTEL_METRICS_EXPORTER

--- a/charts/lfx-v2-access-check/values.yaml
+++ b/charts/lfx-v2-access-check/values.yaml
@@ -77,10 +77,6 @@ app:
     # tracesExporter specifies the traces exporter: "otlp" or "none"
     # (default: "none")
     tracesExporter: "none"
-    # tracesSampleRatio specifies the sampling ratio for traces (0.0 to 1.0)
-    # A value of 1.0 means all traces are sampled, 0.5 means 50% are sampled
-    # (default: "1.0")
-    tracesSampleRatio: "1.0"
     # tracesSampler specifies the OTEL_TRACES_SAMPLER type. Supported values:
     # "always_on", "always_off", "traceidratio", "parentbased_always_on",
     # "parentbased_always_off", "parentbased_traceidratio".

--- a/charts/lfx-v2-access-check/values.yaml
+++ b/charts/lfx-v2-access-check/values.yaml
@@ -81,6 +81,11 @@ app:
     # A value of 1.0 means all traces are sampled, 0.5 means 50% are sampled
     # (default: "1.0")
     tracesSampleRatio: "1.0"
+    # tracesSampler specifies the OTEL_TRACES_SAMPLER type. Supported values:
+    # "always_on", "always_off", "traceidratio", "parentbased_always_on",
+    # "parentbased_always_off", "parentbased_traceidratio".
+    # When empty, the application defaults to parentbased_traceidratio.
+    tracesSampler: ""
     # metricsExporter specifies the metrics exporter: "otlp" or "none"
     # (default: "none")
     metricsExporter: "none"

--- a/charts/lfx-v2-access-check/values.yaml
+++ b/charts/lfx-v2-access-check/values.yaml
@@ -82,6 +82,10 @@ app:
     # "parentbased_always_off", "parentbased_traceidratio".
     # When empty, the application defaults to parentbased_traceidratio.
     tracesSampler: ""
+    # tracesSamplerArg is the argument for the traces sampler (e.g., sampling ratio).
+    # Used by ratio-based samplers: "traceidratio" and "parentbased_traceidratio".
+    # When empty, defaults to "1.0" (sample all).
+    tracesSamplerArg: ""
     # metricsExporter specifies the metrics exporter: "otlp" or "none"
     # (default: "none")
     metricsExporter: "none"

--- a/pkg/utils/otel.go
+++ b/pkg/utils/otel.go
@@ -127,16 +127,6 @@ func OTelConfigFromEnv() OTelConfig {
 	tracesSampler := strings.ToLower(strings.TrimSpace(os.Getenv("OTEL_TRACES_SAMPLER")))
 	tracesSamplerArg := strings.TrimSpace(os.Getenv("OTEL_TRACES_SAMPLER_ARG"))
 
-	// Support deprecated OTEL_TRACES_SAMPLE_RATIO as fallback when OTEL_TRACES_SAMPLER_ARG is unset.
-	if tracesSamplerArg == "" {
-		legacySampleRatio := strings.TrimSpace(os.Getenv("OTEL_TRACES_SAMPLE_RATIO"))
-		if legacySampleRatio != "" {
-			tracesSamplerArg = legacySampleRatio
-			slog.Debug("using deprecated OTEL_TRACES_SAMPLE_RATIO for sampler argument",
-				"provided-value", legacySampleRatio)
-		}
-	}
-
 	slog.With(
 		"service-name", serviceName,
 		"version", serviceVersion,

--- a/pkg/utils/otel.go
+++ b/pkg/utils/otel.go
@@ -127,6 +127,16 @@ func OTelConfigFromEnv() OTelConfig {
 	tracesSampler := strings.ToLower(strings.TrimSpace(os.Getenv("OTEL_TRACES_SAMPLER")))
 	tracesSamplerArg := strings.TrimSpace(os.Getenv("OTEL_TRACES_SAMPLER_ARG"))
 
+	// Support deprecated OTEL_TRACES_SAMPLE_RATIO as fallback when OTEL_TRACES_SAMPLER_ARG is unset.
+	if tracesSamplerArg == "" {
+		legacySampleRatio := strings.TrimSpace(os.Getenv("OTEL_TRACES_SAMPLE_RATIO"))
+		if legacySampleRatio != "" {
+			tracesSamplerArg = legacySampleRatio
+			slog.Debug("using deprecated OTEL_TRACES_SAMPLE_RATIO for sampler argument",
+				"provided-value", legacySampleRatio)
+		}
+	}
+
 	slog.With(
 		"service-name", serviceName,
 		"version", serviceVersion,
@@ -302,11 +312,17 @@ func newSampler(cfg OTelConfig) sdktrace.Sampler {
 	parseRatio := func() float64 {
 		if cfg.TracesSamplerArg != "" {
 			r, err := strconv.ParseFloat(cfg.TracesSamplerArg, 64)
-			if err == nil && r >= 0.0 && r <= 1.0 {
-				return r
+			if err != nil {
+				slog.Warn("OTEL_TRACES_SAMPLER_ARG failed to parse, defaulting to 1.0",
+					"provided-value", cfg.TracesSamplerArg, "error", err)
+				return 1.0
 			}
-			slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, defaulting to 1.0",
-				"provided-value", cfg.TracesSamplerArg, "error", err)
+			if r < 0.0 || r > 1.0 {
+				slog.Warn("OTEL_TRACES_SAMPLER_ARG out of range [0.0, 1.0], defaulting to 1.0",
+					"provided-value", cfg.TracesSamplerArg, "min", 0.0, "max", 1.0)
+				return 1.0
+			}
+			return r
 		}
 		return 1.0
 	}

--- a/pkg/utils/otel.go
+++ b/pkg/utils/otel.go
@@ -446,4 +446,3 @@ func newLoggerProvider(ctx context.Context, cfg OTelConfig, res *resource.Resour
 	)
 	return loggerProvider, nil
 }
-

--- a/pkg/utils/otel.go
+++ b/pkg/utils/otel.go
@@ -300,21 +300,21 @@ func endpointURL(raw string, insecure bool) string {
 // This ensures parent span sampling decisions are always honored.
 func newSampler(cfg OTelConfig) sdktrace.Sampler {
 	parseRatio := func() float64 {
-		if cfg.TracesSamplerArg != "" {
-			r, err := strconv.ParseFloat(cfg.TracesSamplerArg, 64)
-			if err != nil {
-				slog.Warn("OTEL_TRACES_SAMPLER_ARG failed to parse, defaulting to 1.0",
-					"provided-value", cfg.TracesSamplerArg, "error", err)
-				return 1.0
-			}
-			if r < 0.0 || r > 1.0 {
-				slog.Warn("OTEL_TRACES_SAMPLER_ARG out of range [0.0, 1.0], defaulting to 1.0",
-					"provided-value", cfg.TracesSamplerArg, "min", 0.0, "max", 1.0)
-				return 1.0
-			}
-			return r
+		if cfg.TracesSamplerArg == "" {
+			return 1.0
 		}
-		return 1.0
+		r, err := strconv.ParseFloat(cfg.TracesSamplerArg, 64)
+		if err != nil {
+			slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, defaulting to 1.0",
+				"provided-value", cfg.TracesSamplerArg, "error", err)
+			return 1.0
+		}
+		if r < 0.0 || r > 1.0 {
+			slog.Warn("OTEL_TRACES_SAMPLER_ARG out of range [0.0, 1.0], defaulting to 1.0",
+				"provided-value", cfg.TracesSamplerArg)
+			return 1.0
+		}
+		return r
 	}
 
 	switch cfg.TracesSampler {

--- a/pkg/utils/otel.go
+++ b/pkg/utils/otel.go
@@ -67,6 +67,12 @@ type OTelConfig struct {
 	// A value of 1.0 means all traces are sampled, 0.5 means 50% are sampled.
 	// Env: OTEL_TRACES_SAMPLE_RATIO (default: 1.0)
 	TracesSampleRatio float64
+	// TracesSampler specifies the sampler to use for traces.
+	// Env: OTEL_TRACES_SAMPLER (default: "")
+	TracesSampler string
+	// TracesSamplerArg is the argument for the traces sampler.
+	// Env: OTEL_TRACES_SAMPLER_ARG (default: "")
+	TracesSamplerArg string
 	// MetricsExporter specifies the metrics exporter: "otlp" or "none".
 	// Env: OTEL_METRICS_EXPORTER (default: "none")
 	MetricsExporter string
@@ -133,6 +139,9 @@ func OTelConfigFromEnv() OTelConfig {
 		}
 	}
 
+	tracesSampler := strings.ToLower(strings.TrimSpace(os.Getenv("OTEL_TRACES_SAMPLER")))
+	tracesSamplerArg := strings.TrimSpace(os.Getenv("OTEL_TRACES_SAMPLER_ARG"))
+
 	slog.With(
 		"service-name", serviceName,
 		"version", serviceVersion,
@@ -141,6 +150,8 @@ func OTelConfigFromEnv() OTelConfig {
 		"insecure", insecure,
 		"traces-exporter", tracesExporter,
 		"traces-sample-ratio", tracesSampleRatio,
+		"traces-sampler", tracesSampler,
+		"traces-sampler-arg", tracesSamplerArg,
 		"metrics-exporter", metricsExporter,
 		"logs-exporter", logsExporter,
 		"propagators", propagators,
@@ -154,6 +165,8 @@ func OTelConfigFromEnv() OTelConfig {
 		Insecure:          insecure,
 		TracesExporter:    tracesExporter,
 		TracesSampleRatio: tracesSampleRatio,
+		TracesSampler:     tracesSampler,
+		TracesSamplerArg:  tracesSamplerArg,
 		MetricsExporter:   metricsExporter,
 		LogsExporter:      logsExporter,
 		Propagators:       propagators,
@@ -299,25 +312,23 @@ func endpointURL(raw string, insecure bool) string {
 }
 
 // newSampler creates a trace.Sampler from OTEL_TRACES_SAMPLER and
-// OTEL_TRACES_SAMPLER_ARG environment variables, falling back to
+// OTEL_TRACES_SAMPLER_ARG configuration, falling back to
 // parentbased_traceidratio with cfg.TracesSampleRatio when unset.
 // This ensures parent span sampling decisions are always honored.
 func newSampler(cfg OTelConfig) sdktrace.Sampler {
-	sampler := os.Getenv("OTEL_TRACES_SAMPLER")
-	arg := os.Getenv("OTEL_TRACES_SAMPLER_ARG")
-
 	parseRatio := func() float64 {
-		if arg != "" {
-			r, err := strconv.ParseFloat(arg, 64)
+		if cfg.TracesSamplerArg != "" {
+			r, err := strconv.ParseFloat(cfg.TracesSamplerArg, 64)
 			if err == nil && r >= 0.0 && r <= 1.0 {
 				return r
 			}
-			slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, using TracesSampleRatio", "value", arg)
+			slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, using TracesSampleRatio",
+				"provided-value", cfg.TracesSamplerArg, "error", err)
 		}
 		return cfg.TracesSampleRatio
 	}
 
-	switch sampler {
+	switch cfg.TracesSampler {
 	case "always_on":
 		return sdktrace.AlwaysSample()
 	case "always_off":
@@ -330,8 +341,12 @@ func newSampler(cfg OTelConfig) sdktrace.Sampler {
 		return sdktrace.ParentBased(sdktrace.NeverSample())
 	case "parentbased_traceidratio":
 		return sdktrace.ParentBased(sdktrace.TraceIDRatioBased(parseRatio()))
-	default: // empty/unknown → parent-based with configured ratio
-		return sdktrace.ParentBased(sdktrace.TraceIDRatioBased(cfg.TracesSampleRatio))
+	default:
+		if cfg.TracesSampler != "" {
+			slog.Warn("unknown OTEL_TRACES_SAMPLER, falling back to parentbased_traceidratio",
+				"provided-value", cfg.TracesSampler, "fallback-ratio", cfg.TracesSampleRatio)
+		}
+		return sdktrace.ParentBased(sdktrace.TraceIDRatioBased(parseRatio()))
 	}
 }
 

--- a/pkg/utils/otel.go
+++ b/pkg/utils/otel.go
@@ -63,10 +63,6 @@ type OTelConfig struct {
 	// TracesExporter specifies the traces exporter: "otlp" or "none".
 	// Env: OTEL_TRACES_EXPORTER (default: "none")
 	TracesExporter string
-	// TracesSampleRatio specifies the sampling ratio for traces (0.0 to 1.0).
-	// A value of 1.0 means all traces are sampled, 0.5 means 50% are sampled.
-	// Env: OTEL_TRACES_SAMPLE_RATIO (default: 1.0)
-	TracesSampleRatio float64
 	// TracesSampler specifies the sampler to use for traces.
 	// Env: OTEL_TRACES_SAMPLER (default: "")
 	TracesSampler string
@@ -124,21 +120,6 @@ func OTelConfigFromEnv() OTelConfig {
 		propagators = "tracecontext,baggage"
 	}
 
-	tracesSampleRatio := 1.0
-	if ratio := os.Getenv("OTEL_TRACES_SAMPLE_RATIO"); ratio != "" {
-		if parsed, err := strconv.ParseFloat(ratio, 64); err == nil {
-			if parsed >= 0.0 && parsed <= 1.0 {
-				tracesSampleRatio = parsed
-			} else {
-				slog.Warn("OTEL_TRACES_SAMPLE_RATIO must be between 0.0 and 1.0, using default 1.0",
-					"provided-value", ratio)
-			}
-		} else {
-			slog.Warn("invalid OTEL_TRACES_SAMPLE_RATIO value, using default 1.0",
-				"provided-value", ratio, "error", err)
-		}
-	}
-
 	tracesSampler := strings.ToLower(strings.TrimSpace(os.Getenv("OTEL_TRACES_SAMPLER")))
 	tracesSamplerArg := strings.TrimSpace(os.Getenv("OTEL_TRACES_SAMPLER_ARG"))
 
@@ -149,7 +130,6 @@ func OTelConfigFromEnv() OTelConfig {
 		"endpoint", endpoint,
 		"insecure", insecure,
 		"traces-exporter", tracesExporter,
-		"traces-sample-ratio", tracesSampleRatio,
 		"traces-sampler", tracesSampler,
 		"traces-sampler-arg", tracesSamplerArg,
 		"metrics-exporter", metricsExporter,
@@ -158,18 +138,17 @@ func OTelConfigFromEnv() OTelConfig {
 	).Debug("OTelConfig")
 
 	return OTelConfig{
-		ServiceName:       serviceName,
-		ServiceVersion:    serviceVersion,
-		Protocol:          protocol,
-		Endpoint:          endpoint,
-		Insecure:          insecure,
-		TracesExporter:    tracesExporter,
-		TracesSampleRatio: tracesSampleRatio,
-		TracesSampler:     tracesSampler,
-		TracesSamplerArg:  tracesSamplerArg,
-		MetricsExporter:   metricsExporter,
-		LogsExporter:      logsExporter,
-		Propagators:       propagators,
+		ServiceName:      serviceName,
+		ServiceVersion:   serviceVersion,
+		Protocol:         protocol,
+		Endpoint:         endpoint,
+		Insecure:         insecure,
+		TracesExporter:   tracesExporter,
+		TracesSampler:    tracesSampler,
+		TracesSamplerArg: tracesSamplerArg,
+		MetricsExporter:  metricsExporter,
+		LogsExporter:     logsExporter,
+		Propagators:      propagators,
 	}
 }
 
@@ -313,7 +292,7 @@ func endpointURL(raw string, insecure bool) string {
 
 // newSampler creates a trace.Sampler from OTEL_TRACES_SAMPLER and
 // OTEL_TRACES_SAMPLER_ARG configuration, falling back to
-// parentbased_traceidratio with cfg.TracesSampleRatio when unset.
+// parentbased_traceidratio with a default ratio of 1.0 when unset.
 // This ensures parent span sampling decisions are always honored.
 func newSampler(cfg OTelConfig) sdktrace.Sampler {
 	parseRatio := func() float64 {
@@ -322,10 +301,10 @@ func newSampler(cfg OTelConfig) sdktrace.Sampler {
 			if err == nil && r >= 0.0 && r <= 1.0 {
 				return r
 			}
-			slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, using TracesSampleRatio",
+			slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, defaulting to 1.0",
 				"provided-value", cfg.TracesSamplerArg, "error", err)
 		}
-		return cfg.TracesSampleRatio
+		return 1.0
 	}
 
 	switch cfg.TracesSampler {
@@ -344,7 +323,7 @@ func newSampler(cfg OTelConfig) sdktrace.Sampler {
 	default:
 		if cfg.TracesSampler != "" {
 			slog.Warn("unknown OTEL_TRACES_SAMPLER, falling back to parentbased_traceidratio",
-				"provided-value", cfg.TracesSampler, "fallback-ratio", cfg.TracesSampleRatio)
+				"provided-value", cfg.TracesSampler)
 		}
 		return sdktrace.ParentBased(sdktrace.TraceIDRatioBased(parseRatio()))
 	}

--- a/pkg/utils/otel.go
+++ b/pkg/utils/otel.go
@@ -64,10 +64,14 @@ type OTelConfig struct {
 	// Env: OTEL_TRACES_EXPORTER (default: "none")
 	TracesExporter string
 	// TracesSampler specifies the sampler to use for traces.
-	// Env: OTEL_TRACES_SAMPLER (default: "")
+	// Env: OTEL_TRACES_SAMPLER (default: "parentbased_traceidratio")
+	// Supported values: "always_on", "always_off", "traceidratio",
+	// "parentbased_always_on", "parentbased_always_off", "parentbased_traceidratio".
+	// When empty, the application defaults to parentbased_traceidratio.
 	TracesSampler string
-	// TracesSamplerArg is the argument for the traces sampler.
-	// Env: OTEL_TRACES_SAMPLER_ARG (default: "")
+	// TracesSamplerArg is the argument for the traces sampler (e.g., sampling ratio).
+	// Env: OTEL_TRACES_SAMPLER_ARG (default: "1.0")
+	// Used by ratio-based samplers: "traceidratio" and "parentbased_traceidratio".
 	TracesSamplerArg string
 	// MetricsExporter specifies the metrics exporter: "otlp" or "none".
 	// Env: OTEL_METRICS_EXPORTER (default: "none")
@@ -321,11 +325,12 @@ func newSampler(cfg OTelConfig) sdktrace.Sampler {
 	case "parentbased_traceidratio":
 		return sdktrace.ParentBased(sdktrace.TraceIDRatioBased(parseRatio()))
 	default:
+		ratio := parseRatio()
 		if cfg.TracesSampler != "" {
 			slog.Warn("unknown OTEL_TRACES_SAMPLER, falling back to parentbased_traceidratio",
-				"provided-value", cfg.TracesSampler)
+				"provided-value", cfg.TracesSampler, "effective-ratio", ratio)
 		}
-		return sdktrace.ParentBased(sdktrace.TraceIDRatioBased(parseRatio()))
+		return sdktrace.ParentBased(sdktrace.TraceIDRatioBased(ratio))
 	}
 }
 

--- a/pkg/utils/otel.go
+++ b/pkg/utils/otel.go
@@ -298,6 +298,43 @@ func endpointURL(raw string, insecure bool) string {
 	return "https://" + raw
 }
 
+// newSampler creates a trace.Sampler from OTEL_TRACES_SAMPLER and
+// OTEL_TRACES_SAMPLER_ARG environment variables, falling back to
+// parentbased_traceidratio with cfg.TracesSampleRatio when unset.
+// This ensures parent span sampling decisions are always honored.
+func newSampler(cfg OTelConfig) sdktrace.Sampler {
+	sampler := os.Getenv("OTEL_TRACES_SAMPLER")
+	arg := os.Getenv("OTEL_TRACES_SAMPLER_ARG")
+
+	parseRatio := func() float64 {
+		if arg != "" {
+			r, err := strconv.ParseFloat(arg, 64)
+			if err == nil && r >= 0.0 && r <= 1.0 {
+				return r
+			}
+			slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, using TracesSampleRatio", "value", arg)
+		}
+		return cfg.TracesSampleRatio
+	}
+
+	switch sampler {
+	case "always_on":
+		return sdktrace.AlwaysSample()
+	case "always_off":
+		return sdktrace.NeverSample()
+	case "traceidratio":
+		return sdktrace.TraceIDRatioBased(parseRatio())
+	case "parentbased_always_on":
+		return sdktrace.ParentBased(sdktrace.AlwaysSample())
+	case "parentbased_always_off":
+		return sdktrace.ParentBased(sdktrace.NeverSample())
+	case "parentbased_traceidratio":
+		return sdktrace.ParentBased(sdktrace.TraceIDRatioBased(parseRatio()))
+	default: // empty/unknown → parent-based with configured ratio
+		return sdktrace.ParentBased(sdktrace.TraceIDRatioBased(cfg.TracesSampleRatio))
+	}
+}
+
 // newTraceProvider creates a TracerProvider with an OTLP exporter configured based on the protocol setting.
 func newTraceProvider(ctx context.Context, cfg OTelConfig, res *resource.Resource) (*sdktrace.TracerProvider, error) {
 	var exporter sdktrace.SpanExporter
@@ -329,7 +366,7 @@ func newTraceProvider(ctx context.Context, cfg OTelConfig, res *resource.Resourc
 
 	traceProvider := sdktrace.NewTracerProvider(
 		sdktrace.WithResource(res),
-		sdktrace.WithSampler(sdktrace.TraceIDRatioBased(cfg.TracesSampleRatio)),
+		sdktrace.WithSampler(newSampler(cfg)),
 		sdktrace.WithBatcher(exporter,
 			sdktrace.WithBatchTimeout(time.Second),
 		),

--- a/pkg/utils/otel_test.go
+++ b/pkg/utils/otel_test.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"testing"
 
-	"go.opentelemetry.io/otel/trace"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // TestOTelConfigFromEnv_Defaults verifies that OTelConfigFromEnv returns
@@ -99,12 +99,12 @@ func TestOTelConfigFromEnv_UnsupportedProtocol(t *testing.T) {
 // disabled, and that the returned shutdown function works correctly.
 func TestSetupOTelSDKWithConfig_AllDisabled(t *testing.T) {
 	cfg := OTelConfig{
-		ServiceName:    "test-service",
-		ServiceVersion: "1.0.0",
-		Protocol:       OTelProtocolGRPC,
-		TracesExporter: OTelExporterNone,
+		ServiceName:     "test-service",
+		ServiceVersion:  "1.0.0",
+		Protocol:        OTelProtocolGRPC,
+		TracesExporter:  OTelExporterNone,
 		MetricsExporter: OTelExporterNone,
-		LogsExporter:   OTelExporterNone,
+		LogsExporter:    OTelExporterNone,
 	}
 
 	ctx := context.Background()
@@ -291,15 +291,15 @@ func TestSetupOTelSDKWithConfig_IPEndpoint(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "127.0.0.1:4317")
 
 	cfg := OTelConfig{
-		ServiceName:    "test-service",
-		ServiceVersion: "1.0.0",
-		Protocol:       OTelProtocolGRPC,
-		Endpoint:       "127.0.0.1:4317",
-		Insecure:       true,
-		TracesExporter: OTelExporterOTLP,
+		ServiceName:     "test-service",
+		ServiceVersion:  "1.0.0",
+		Protocol:        OTelProtocolGRPC,
+		Endpoint:        "127.0.0.1:4317",
+		Insecure:        true,
+		TracesExporter:  OTelExporterOTLP,
 		MetricsExporter: OTelExporterNone,
-		LogsExporter:   OTelExporterNone,
-		Propagators:    "tracecontext,baggage",
+		LogsExporter:    OTelExporterNone,
+		Propagators:     "tracecontext,baggage",
 	}
 
 	ctx := context.Background()

--- a/pkg/utils/otel_test.go
+++ b/pkg/utils/otel_test.go
@@ -5,8 +5,10 @@ package utils
 
 import (
 	"context"
-
 	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
 // TestOTelConfigFromEnv_Defaults verifies that OTelConfigFromEnv returns
@@ -326,7 +328,6 @@ func TestSetupOTelSDKWithConfig_IPEndpoint(t *testing.T) {
 // supported OTEL_TRACES_SAMPLER values, including the default (empty) case.
 func TestNewSampler(t *testing.T) {
 	cfg := OTelConfig{TracesSampleRatio: 0.5}
-
 	tests := []struct {
 		name    string
 		sampler string
@@ -341,15 +342,17 @@ func TestNewSampler(t *testing.T) {
 		{"parentbased_traceidratio", "parentbased_traceidratio", "0.5"},
 		{"unknown", "unknown", ""},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("OTEL_TRACES_SAMPLER", tt.sampler)
-			t.Setenv("OTEL_TRACES_SAMPLER_ARG", tt.arg)
-
-			s := newSampler(cfg)
+			c := cfg
+			c.TracesSampler = tt.sampler
+			c.TracesSamplerArg = tt.arg
+			s := newSampler(c)
 			if s == nil {
-				t.Errorf("newSampler(%q) returned nil", tt.sampler)
+				t.Fatalf("newSampler(%q) returned nil", tt.sampler)
+			}
+			if s.Description() == "" {
+				t.Errorf("newSampler(%q).Description() is empty", tt.sampler)
 			}
 		})
 	}
@@ -358,12 +361,28 @@ func TestNewSampler(t *testing.T) {
 // TestNewSampler_InvalidArg verifies that an invalid OTEL_TRACES_SAMPLER_ARG
 // falls back to cfg.TracesSampleRatio without panicking.
 func TestNewSampler_InvalidArg(t *testing.T) {
-	cfg := OTelConfig{TracesSampleRatio: 0.5}
-	t.Setenv("OTEL_TRACES_SAMPLER", "parentbased_traceidratio")
-	t.Setenv("OTEL_TRACES_SAMPLER_ARG", "invalid")
-
+	cfg := OTelConfig{
+		TracesSampleRatio: 0.5,
+		TracesSampler:     "parentbased_traceidratio",
+		TracesSamplerArg:  "invalid",
+	}
 	s := newSampler(cfg)
 	if s == nil {
-		t.Error("newSampler returned nil for invalid OTEL_TRACES_SAMPLER_ARG")
+		t.Fatal("newSampler returned nil for invalid OTEL_TRACES_SAMPLER_ARG")
+	}
+}
+
+// TestNewSampler_ParentHonored verifies that the default sampler respects
+// parent span sampling decisions (parentbased_traceidratio).
+func TestNewSampler_ParentHonored(t *testing.T) {
+	cfg := OTelConfig{TracesSampleRatio: 1.0}
+	s := newSampler(cfg) // default = parentbased_traceidratio
+
+	// With a sampled parent, child should also be sampled
+	sampledParent := trace.SpanContext{}.WithTraceFlags(trace.FlagsSampled)
+	parentCtx := trace.ContextWithRemoteSpanContext(context.Background(), sampledParent)
+	result := s.ShouldSample(sdktrace.SamplingParameters{ParentContext: parentCtx})
+	if result.Decision != sdktrace.RecordAndSample {
+		t.Errorf("expected RecordAndSample with sampled parent, got %v", result.Decision)
 	}
 }

--- a/pkg/utils/otel_test.go
+++ b/pkg/utils/otel_test.go
@@ -368,11 +368,33 @@ func TestNewSampler_ParentHonored(t *testing.T) {
 	cfg := OTelConfig{}
 	s := newSampler(cfg) // default = parentbased_traceidratio
 
-	// With a sampled parent, child should also be sampled
-	sampledParent := trace.SpanContext{}.WithTraceFlags(trace.FlagsSampled)
+	// Create a valid remote parent span context with non-zero TraceID/SpanID
+	traceID, _ := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+	spanID, _ := trace.SpanIDFromHex("00f067aa0ba902b7")
+
+	// Test 1: With a sampled parent, child should also be sampled
+	sampledParent := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
 	parentCtx := trace.ContextWithRemoteSpanContext(context.Background(), sampledParent)
 	result := s.ShouldSample(sdktrace.SamplingParameters{ParentContext: parentCtx})
 	if result.Decision != sdktrace.RecordAndSample {
 		t.Errorf("expected RecordAndSample with sampled parent, got %v", result.Decision)
+	}
+
+	// Test 2: With an unsampled parent, child should not be sampled
+	unsampledParent := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: 0, // not sampled
+		Remote:     true,
+	})
+	parentCtx = trace.ContextWithRemoteSpanContext(context.Background(), unsampledParent)
+	result = s.ShouldSample(sdktrace.SamplingParameters{ParentContext: parentCtx})
+	if result.Decision != sdktrace.Drop {
+		t.Errorf("expected Drop with unsampled parent, got %v", result.Decision)
 	}
 }

--- a/pkg/utils/otel_test.go
+++ b/pkg/utils/otel_test.go
@@ -34,9 +34,6 @@ func TestOTelConfigFromEnv_Defaults(t *testing.T) {
 	if cfg.TracesExporter != OTelExporterNone {
 		t.Errorf("expected default TracesExporter %q, got %q", OTelExporterNone, cfg.TracesExporter)
 	}
-	if cfg.TracesSampleRatio != 1.0 {
-		t.Errorf("expected default TracesSampleRatio 1.0, got %f", cfg.TracesSampleRatio)
-	}
 	if cfg.MetricsExporter != OTelExporterNone {
 		t.Errorf("expected default MetricsExporter %q, got %q", OTelExporterNone, cfg.MetricsExporter)
 	}
@@ -54,7 +51,6 @@ func TestOTelConfigFromEnv_CustomValues(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "localhost:4318")
 	t.Setenv("OTEL_EXPORTER_OTLP_INSECURE", "true")
 	t.Setenv("OTEL_TRACES_EXPORTER", "otlp")
-	t.Setenv("OTEL_TRACES_SAMPLE_RATIO", "0.5")
 	t.Setenv("OTEL_METRICS_EXPORTER", "otlp")
 	t.Setenv("OTEL_LOGS_EXPORTER", "otlp")
 
@@ -77,9 +73,6 @@ func TestOTelConfigFromEnv_CustomValues(t *testing.T) {
 	}
 	if cfg.TracesExporter != OTelExporterOTLP {
 		t.Errorf("expected TracesExporter %q, got %q", OTelExporterOTLP, cfg.TracesExporter)
-	}
-	if cfg.TracesSampleRatio != 0.5 {
-		t.Errorf("expected TracesSampleRatio 0.5, got %f", cfg.TracesSampleRatio)
 	}
 	if cfg.MetricsExporter != OTelExporterOTLP {
 		t.Errorf("expected MetricsExporter %q, got %q", OTelExporterOTLP, cfg.MetricsExporter)
@@ -106,13 +99,12 @@ func TestOTelConfigFromEnv_UnsupportedProtocol(t *testing.T) {
 // disabled, and that the returned shutdown function works correctly.
 func TestSetupOTelSDKWithConfig_AllDisabled(t *testing.T) {
 	cfg := OTelConfig{
-		ServiceName:       "test-service",
-		ServiceVersion:    "1.0.0",
-		Protocol:          OTelProtocolGRPC,
-		TracesExporter:    OTelExporterNone,
-		TracesSampleRatio: 1.0,
-		MetricsExporter:   OTelExporterNone,
-		LogsExporter:      OTelExporterNone,
+		ServiceName:    "test-service",
+		ServiceVersion: "1.0.0",
+		Protocol:       OTelProtocolGRPC,
+		TracesExporter: OTelExporterNone,
+		MetricsExporter: OTelExporterNone,
+		LogsExporter:   OTelExporterNone,
 	}
 
 	ctx := context.Background()
@@ -299,16 +291,15 @@ func TestSetupOTelSDKWithConfig_IPEndpoint(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "127.0.0.1:4317")
 
 	cfg := OTelConfig{
-		ServiceName:       "test-service",
-		ServiceVersion:    "1.0.0",
-		Protocol:          OTelProtocolGRPC,
-		Endpoint:          "127.0.0.1:4317",
-		Insecure:          true,
-		TracesExporter:    OTelExporterOTLP,
-		TracesSampleRatio: 1.0,
-		MetricsExporter:   OTelExporterNone,
-		LogsExporter:      OTelExporterNone,
-		Propagators:       "tracecontext,baggage",
+		ServiceName:    "test-service",
+		ServiceVersion: "1.0.0",
+		Protocol:       OTelProtocolGRPC,
+		Endpoint:       "127.0.0.1:4317",
+		Insecure:       true,
+		TracesExporter: OTelExporterOTLP,
+		MetricsExporter: OTelExporterNone,
+		LogsExporter:   OTelExporterNone,
+		Propagators:    "tracecontext,baggage",
 	}
 
 	ctx := context.Background()
@@ -327,7 +318,7 @@ func TestSetupOTelSDKWithConfig_IPEndpoint(t *testing.T) {
 // TestNewSampler verifies that newSampler returns a non-nil sampler for all
 // supported OTEL_TRACES_SAMPLER values, including the default (empty) case.
 func TestNewSampler(t *testing.T) {
-	cfg := OTelConfig{TracesSampleRatio: 0.5}
+	cfg := OTelConfig{}
 	tests := []struct {
 		name    string
 		sampler string
@@ -359,12 +350,11 @@ func TestNewSampler(t *testing.T) {
 }
 
 // TestNewSampler_InvalidArg verifies that an invalid OTEL_TRACES_SAMPLER_ARG
-// falls back to cfg.TracesSampleRatio without panicking.
+// falls back to default ratio of 1.0 without panicking.
 func TestNewSampler_InvalidArg(t *testing.T) {
 	cfg := OTelConfig{
-		TracesSampleRatio: 0.5,
-		TracesSampler:     "parentbased_traceidratio",
-		TracesSamplerArg:  "invalid",
+		TracesSampler:    "parentbased_traceidratio",
+		TracesSamplerArg: "invalid",
 	}
 	s := newSampler(cfg)
 	if s == nil {
@@ -375,7 +365,7 @@ func TestNewSampler_InvalidArg(t *testing.T) {
 // TestNewSampler_ParentHonored verifies that the default sampler respects
 // parent span sampling decisions (parentbased_traceidratio).
 func TestNewSampler_ParentHonored(t *testing.T) {
-	cfg := OTelConfig{TracesSampleRatio: 1.0}
+	cfg := OTelConfig{}
 	s := newSampler(cfg) // default = parentbased_traceidratio
 
 	// With a sampled parent, child should also be sampled

--- a/pkg/utils/otel_test.go
+++ b/pkg/utils/otel_test.go
@@ -321,3 +321,49 @@ func TestSetupOTelSDKWithConfig_IPEndpoint(t *testing.T) {
 
 	_ = shutdown(ctx)
 }
+
+// TestNewSampler verifies that newSampler returns a non-nil sampler for all
+// supported OTEL_TRACES_SAMPLER values, including the default (empty) case.
+func TestNewSampler(t *testing.T) {
+	cfg := OTelConfig{TracesSampleRatio: 0.5}
+
+	tests := []struct {
+		name    string
+		sampler string
+		arg     string
+	}{
+		{"default (empty)", "", ""},
+		{"always_on", "always_on", ""},
+		{"always_off", "always_off", ""},
+		{"traceidratio", "traceidratio", "0.5"},
+		{"parentbased_always_on", "parentbased_always_on", ""},
+		{"parentbased_always_off", "parentbased_always_off", ""},
+		{"parentbased_traceidratio", "parentbased_traceidratio", "0.5"},
+		{"unknown", "unknown", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OTEL_TRACES_SAMPLER", tt.sampler)
+			t.Setenv("OTEL_TRACES_SAMPLER_ARG", tt.arg)
+
+			s := newSampler(cfg)
+			if s == nil {
+				t.Errorf("newSampler(%q) returned nil", tt.sampler)
+			}
+		})
+	}
+}
+
+// TestNewSampler_InvalidArg verifies that an invalid OTEL_TRACES_SAMPLER_ARG
+// falls back to cfg.TracesSampleRatio without panicking.
+func TestNewSampler_InvalidArg(t *testing.T) {
+	cfg := OTelConfig{TracesSampleRatio: 0.5}
+	t.Setenv("OTEL_TRACES_SAMPLER", "parentbased_traceidratio")
+	t.Setenv("OTEL_TRACES_SAMPLER_ARG", "invalid")
+
+	s := newSampler(cfg)
+	if s == nil {
+		t.Error("newSampler returned nil for invalid OTEL_TRACES_SAMPLER_ARG")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes LFXV2-1734 — all Go service spans have \`parentid: 0\` in Datadog because \`TraceIDRatioBased\` makes independent sampling decisions, ignoring incoming \`traceparent\` headers.

## Changes

**\`pkg/utils/otel.go\`** — Replace bare \`sdktrace.TraceIDRatioBased(ratio)\` with a new \`newSampler(cfg)\` function that:
- Reads \`OTEL_TRACES_SAMPLER\` / \`OTEL_TRACES_SAMPLER_ARG\` (standard OTel env vars)
- Defaults to \`parentbased_traceidratio\` with ratio \`1.0\` when unset
- Supports all 6 OTel sampler types: \`always_on\`, \`always_off\`, \`traceidratio\`, \`parentbased_always_on\`, \`parentbased_always_off\`, \`parentbased_traceidratio\`
- Removes \`TracesSampleRatio\` / \`OTEL_TRACES_SAMPLE_RATIO\` entirely — no backward compatibility fallback; configure sampling via \`OTEL_TRACES_SAMPLER_ARG\`

**\`pkg/utils/otel_test.go\`** — Added \`TestNewSampler\`, \`TestNewSampler_InvalidArg\`, and \`TestNewSampler_ParentHonored\`

**\`charts/lfx-v2-access-check/templates/deployment.yaml\`** — Renders \`OTEL_TRACES_SAMPLER\` when \`app.otel.tracesSampler\` is non-empty; renders \`OTEL_TRACES_SAMPLER_ARG\` when \`app.otel.tracesSamplerArg\` is non-empty (independent conditions)

**\`charts/lfx-v2-access-check/values.yaml\`** — Added \`tracesSampler: ""\` and \`tracesSamplerArg: ""\` to \`app.otel\`

## Why

\`TraceIDRatioBased\` re-decides sampling per span regardless of the parent's sampling flag. Wrapping with \`parentbased_traceidratio\` ensures child spans always follow the parent's decision, restoring end-to-end trace continuity.

\`OTEL_TRACES_SAMPLER_ARG\` replaces the old \`OTEL_TRACES_SAMPLE_RATIO\` / \`TracesSampleRatio\` mechanism. All deployments have been updated in ArgoCD values to use \`tracesSamplerArg\` directly. No backward compatibility fallback is provided.

Issue: LFXV2-1734