### PR TITLE
docs: repo-owned access-check guidance and contract (LFXV2-2015)

### DIFF
--- a/.claude/rules/access-check-boundaries.md
+++ b/.claude/rules/access-check-boundaries.md
@@ -1,0 +1,20 @@
+---
+description: Access-check service boundaries, do not publish to indexer/fga-sync, centralize subject constants, no order assumptions
+paths:
+  - '**/*.go'
+  - 'design/**'
+  - 'pkg/constants/**'
+  - 'charts/**'
+  - 'docs/**'
+  - '.claude/**'
+---
+
+# Access-check service boundaries
+
+- Do not add resource ownership, KV storage, index publishing, or access mutation publishing in this service. It is a synchronous request/reply consumer over `lfx-v2-fga-sync`.
+- Centralize NATS subject constants. Never hardcode subject strings inside handlers, service code, or design files.
+- Do not assume any ordering of responses returned from fga-sync. Match results by object, relation, and user identity, not by incidental NATS response position.
+- Treat `lfx-v2-fga-sync` as the authoritative source for permission semantics, tuple writes, and the check response format.
+- Do not add Heimdall `openfga_check` authorizer rules for `/access-check` or `/my-grants` in this chart. The RuleSet authenticates callers; fga-sync authorization decisions are returned by this service as data.
+
+Canonical contract: `lfx-v2-fga-sync/docs/fga-sync-contract.md`.

--- a/.claude/skills/access-check-dev/SKILL.md
+++ b/.claude/skills/access-check-dev/SKILL.md
@@ -49,7 +49,7 @@ For platform composition, V2 service classes, and cross-service handoffs, use `l
 ## Request context
 
 - Middleware in `internal/middleware/` owns request context setup. Service-layer code must not read HTTP headers directly.
-- Propagate `request_id` and `principal` only through repo helpers and typed context keys (no bare string keys).
+- Propagate `request_id` and `principal` only through repo helpers and the context keys defined in `pkg/constants` (`ClaimsContextKey` for claims, `constants.RequestIDHeader` for the request ID), never ad-hoc string literals.
 - Forward context values into NATS calls only when the receiving subject's contract needs them.
 
 ## My grants

--- a/.claude/skills/access-check-dev/SKILL.md
+++ b/.claude/skills/access-check-dev/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: access-check-dev
+description: Repo-local Go coding conventions and access-check implementation truth for lfx-v2-access-check. Auto-attaches on Go, Goa design, generated-code, Makefile, chart, docs, and local Claude guidance paths. Covers generated-code boundaries, logging, errors, request context, tests, formatting, plus the HTTP-over-NATS wrapper pattern, centralized subject constants, unordered response semantics, my-grants direct tuple reads, and the do-not-publish-index/access-mutation rule. Defers cross-repo flow and service-class discussion to lfx-skills:lfx-platform-architecture and tuple/access-check contract semantics to lfx-v2-fga-sync.
+paths:
+  - "**/*.go"
+  - "go.mod"
+  - "go.sum"
+  - "Makefile"
+  - "CLAUDE.md"
+  - "README.md"
+  - "design/**"
+  - "gen/**"
+  - "charts/**"
+  - "docs/**"
+  - ".claude/rules/**"
+  - ".claude/skills/access-check-dev/**"
+allowed-tools: Read, Glob, Grep, Edit, Write, Bash
+---
+
+# Development Conventions
+
+Repo-local conventions for `lfx-v2-access-check`. Read this first when editing any Go, Goa design, or chart file in this repo.
+
+This service is a thin HTTP wrapper over the access-check contract owned by `lfx-v2-fga-sync`. Tuple semantics, OpenFGA model boundaries, and the canonical access-check envelope live in `lfx-v2-fga-sync/docs/fga-sync-contract.md`. Keep the repo-local rule `.claude/rules/access-check-boundaries.md` aligned with that consumer-service boundary.
+
+For platform composition, V2 service classes, and cross-service handoffs, use `lfx-skills:lfx-platform-architecture`. For cross-repo ownership routing, use `lfx-skills:lfx`.
+
+## Generated code
+
+- Do not edit files under `gen/` by hand. Change `design/access-svc.go` or `design/types.go`, then run `make apigen`.
+- Keep hand-written implementation under `cmd/`, `internal/`, `pkg/`. Match existing package layout and constructor style.
+- Preserve required license headers on new files.
+
+## Logging
+
+- Use `log/slog` or this repo's `pkg/log` wrapper. Never use `fmt.Println`, `fmt.Printf`, `log.Print*`, or `log.Println` for runtime service logging.
+- Include stable structured fields when available: `request_id`, `principal`, `object_type`, `object_id`, `relation`, `operation`, and `subject` for NATS calls.
+- Never log JWTs, bearer headers, raw token strings, secrets, or full request payloads that may contain user identifiers beyond `principal`.
+- Honor `DEBUG` and any `LOG_LEVEL` env var the repo already reads.
+
+## Errors
+
+- Use this repo's existing error helpers in `pkg/constants/errors.go`. Do not introduce a parallel sentinel-error family.
+- Preserve the error set this service emits at the Goa boundary: request validation to 400, JWT validation to 401, unexpected local/upstream response shape to 500, and NATS dependency or request/reply failures to 503. There is no 403 path in this service; the Helm RuleSet authenticates and then uses `allow_all` because authorization decisions are returned as response data. See the full mapping in `docs/access-check-contract.md`.
+- Wrap upstream errors with `fmt.Errorf("...: %w", err)` so `errors.Is` and `errors.Unwrap` keep working.
+- Never return raw upstream NATS error payloads or fga-sync replies to clients. Translate at the service or Goa boundary.
+- This service never returns a partial-success body. Either every request was evaluated (200) or the call fails.
+
+## Request context
+
+- Middleware in `internal/middleware/` owns request context setup. Service-layer code must not read HTTP headers directly.
+- Propagate `request_id` and `principal` only through repo helpers and typed context keys (no bare string keys).
+- Forward context values into NATS calls only when the receiving subject's contract needs them.
+
+## My grants
+
+`GET /my-grants` is not a paginated HTTP list endpoint. It calls
+`lfx.access_check.read_tuples` with JSON `{"user":"user:{principal}","object_type":"..."}`.
+fga-sync paginates OpenFGA internally and this service returns the full direct-tuple
+result set as `{"grants":[...]}`. Do not add local pagination parameters unless the
+HTTP contract and fga-sync contract are changed together.
+
+## Tests
+
+- Depend on interfaces (`internal/domain/contracts/`) for NATS, auth, and config. Use the mocks under `internal/mocks/` and `test/integration/mocks.go`.
+- Use table-driven tests for branching behavior. Co-locate `*_test.go` with the code under test.
+- Run `make test` (race detection enabled) before handing off. Integration tests live in `test/integration/` and run against mocks, no external services required.
+
+## Formatting and review hygiene
+
+- Run `make fmt` and `make lint` on Go changes.
+- Update `docs/access-check-contract.md` in the same change when the HTTP surface, error mapping, or timeout semantics change.
+- Update `references/nats-messaging.md` when the NATS subject set, request envelope, or response shape changes.
+
+## Access-check specifics
+
+This repo is a proxy/consumer service in the sense of `lfx-skills:lfx-platform-architecture`. Three things are non-negotiable here.
+
+### HTTP-over-NATS wrapper pattern
+
+Every business endpoint follows the same shape:
+
+1. Goa-validated HTTP request enters the handler.
+2. Goa auth invokes `JWTAuth`, which validates the Heimdall-issued JWT through `internal/infrastructure/auth` and stores `HeimdallClaims` in context.
+3. Handler builds the fga-sync request payload, appending `@user:{principal}` where the contract requires it.
+4. `internal/infrastructure/messaging` issues a single `nats.Request` against an `lfx.access_check.*` subject with a bounded timeout.
+5. Handler aggregates the reply and returns a single response. No partial success.
+
+There is no JetStream KV ownership here. There is no publish/subscribe loop. The only NATS pattern used is synchronous request/reply.
+
+### Centralized subject constants
+
+All NATS subject strings live in `pkg/constants/messaging.go` (currently `AccessCheckSubject` and `ReadTuplesSubject`). Never hardcode subject strings inside handlers, service code, design files, or tests. Adding a new fga-sync subject means adding a constant first, then using it.
+
+### Unordered response semantics
+
+`fga-sync` returns cached hits before fresh OpenFGA checks, so reply lines are not in request order. Callers (including this service's response aggregation) must match results by the full `object#relation@user` prefix, never by index. Any future change that assumes positional matching is a bug. The contract is fixed in `lfx-v2-fga-sync/docs/fga-sync-contract.md` and surfaced to clients in `docs/access-check-contract.md`.
+
+### Do not publish index or access-mutation messages
+
+This service must never publish to `lfx.index.*` or to fga-sync's tuple-write subjects. It does not own any resource. It does not create, update, or delete tuples. Mutations and indexing belong to the resource-owning services. This is enforced by `.claude/rules/access-check-boundaries.md`.
+
+## When to read which reference
+
+| File | When to read |
+| --- | --- |
+| `references/goa-patterns.md` | Editing `design/` or wiring a new Goa method, error, or security scheme |
+| `references/nats-messaging.md` | Adding or changing a NATS subject, request envelope, or timeout behavior |
+
+## Handoff
+
+- Cross-repo routing, peer-repo paths, "what owns X": `lfx-skills:lfx`.
+- Platform composition, write/read/access-check flows, service classes: `lfx-skills:lfx-platform-architecture`.
+- FGA tuple contract, access-check envelope, OpenFGA model: `lfx-v2-fga-sync/docs/fga-sync-contract.md`.
+- Chart and deployed-values facts: `docs/service-helm-chart.md` for this repo's chart interface, then `lfx-v2-helm/docs/service-chart-patterns.md` for shared chart conventions, then `lfx-v2-argocd/docs/agent-guidance/service-chart-values-handoff.md` for deployed values and chart pins.

--- a/.claude/skills/access-check-dev/references/goa-patterns.md
+++ b/.claude/skills/access-check-dev/references/goa-patterns.md
@@ -1,0 +1,36 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# Goa Patterns (access-check)
+
+Repo-local Goa specifics. Generic Goa concepts and V2 service-class context live in `lfx-skills:lfx-platform-architecture`. Generic Go conventions live in the parent `SKILL.md`. This file documents only what is specific to this repo's design surface.
+
+## Design layout
+
+- Designs live at the repo root in `design/`:
+  - `design/access-svc.go`: API, security scheme, methods, HTTP transport.
+  - `design/types.go`: shared types.
+- Generated code lands in `gen/` after `make apigen`. Never hand-edit `gen/`.
+
+## Methods exposed today
+
+| Method | HTTP | Purpose |
+| --- | --- | --- |
+| `check-access` | `POST /access-check?v=1` | Bulk access check, body is `requests: []string` |
+| `my-grants` | `GET /my-grants?v=1&object_type=...` | Direct grants for the caller on an object type |
+| `livez` | `GET /livez` | Liveness, plaintext OK |
+| `readyz` | `GET /readyz` | Readiness, plaintext OK, checks NATS and JWKS |
+| `Files(...)` | `GET /_access-check/openapi*` | Self-served OpenAPI specs |
+
+## Local deviations
+
+- API version is a query param (`v=1`), not a body field or path segment. Enforced via `Param("version:v")` and `Enum("1")`.
+- Bearer token is captured with `Token("bearer_token", ...)` and `Header("bearer_token:Authorization")`. The service validates the Heimdall-issued JWT via `JWTAuth` before reading the principal from `HeimdallClaims`.
+- `requests` uses `MinLength(1)`, so the HTTP transport rejects an empty JSON array before service code can normalize it to an empty result.
+- No ETag or If-Match wiring. This service has no mutable resource state.
+- Error set per method is the standard four: `BadRequest`, `Unauthorized`, `InternalServerError` (Fault), `ServiceUnavailable` (Temporary + Fault). Map status codes in the `HTTP(...)` block.
+- Examples in payload/result attributes reuse constants from `pkg/constants` (`ExampleProjectAction`, `ExampleCommitteeAction`) so the OpenAPI examples stay aligned with the contract.
+
+## Contract source of truth
+
+The HTTP contract (request, response, unordered-response caveat, error mapping, timeout, and direct-grant behavior) is owned by `docs/access-check-contract.md`. Update that file in the same change as any design-level break or addition.

--- a/.claude/skills/access-check-dev/references/nats-messaging.md
+++ b/.claude/skills/access-check-dev/references/nats-messaging.md
@@ -1,0 +1,42 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# NATS Messaging (access-check)
+
+Repo-local NATS specifics. Platform-level NATS/KV ownership lives in `lfx-skills:lfx-platform-architecture`. The canonical request/reply envelope and tuple semantics live in `lfx-v2-fga-sync/docs/fga-sync-contract.md`. The "do not hardcode subjects, do not assume reply order, do not publish index or mutation messages" rules are stated once in the parent `SKILL.md` and codified in `.claude/rules/access-check-boundaries.md`. This file covers only what is access-check-specific.
+
+## Subjects this service calls
+
+Both constants live in `pkg/constants/messaging.go`. New subjects added here must follow the same pattern.
+
+| Constant | Subject | Pattern | Used by |
+| --- | --- | --- | --- |
+| `AccessCheckSubject` | `lfx.access_check.request` | request/reply | `check-access` handler |
+| `ReadTuplesSubject` | `lfx.access_check.read_tuples` | request/reply | `my-grants` handler |
+
+This service is not a publisher of anything else and is not a subscriber. It owns no JetStream KV bucket.
+
+## Request/reply call shape
+
+`internal/infrastructure/messaging/messaging_repository.go` wraps `nats.Conn.Request`. Every call passes:
+
+- The subject from `pkg/constants/messaging.go`.
+- A pre-serialized payload built by the service layer.
+- A bounded timeout sourced from `pkg/constants/messaging.go` (`DefaultNATSTimeout`, 15s today).
+
+On timeout or transport error the handler returns 503 with a log line. Unexpected reply shapes return 500. There is no retry loop in the handler and no partial-reply path. Caller-side timeouts must be larger than the NATS request timeout so the error response can propagate.
+
+## Connection lifecycle
+
+- Connect at startup with `MaxReconnects(3)`, `ReconnectWait(DefaultNATSReconnectWait)`, `DrainTimeout(DefaultNATSDrainTimeout)`.
+- Async errors and `ClosedHandler` log through `slog`; exhausted reconnects log `ErrMsgNATSMaxReconnects`.
+- Graceful shutdown calls `conn.Drain()`. Do not call `Close()` directly in service paths.
+- `HealthCheck` (used by `readyz`) verifies `IsConnected`, refuses `IsClosed`/`IsDraining`, and uses `FlushWithContext` with `DefaultNATSTimeout` to confirm responsiveness.
+
+## When subjects or payloads change
+
+1. Update the constant in `pkg/constants/messaging.go`.
+2. Update the call site and any handler that consumes the reply.
+3. Coordinate with `lfx-v2-fga-sync` for the matching responder change. The envelope is theirs.
+4. Update `docs/access-check-contract.md` if the change is visible to HTTP callers.
+5. Update this file's subject table.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,32 @@
 # LFX Access Check Service
 
+> **Central LFX skills:**
+> - `lfx-skills:lfx` for cross-repo tasks, "where does X live" questions, owner/peer repo routing, and missing checkouts.
+> - `lfx-skills:lfx-platform-architecture` for platform composition, V2 service classes (this service is a proxy/consumer), write/read/access-check flows, NATS/KV ownership, and handoffs across FGA, indexer, query, Heimdall, OpenFGA, Helm, ArgoCD.
+> - The repo-local `access-check-dev` skill auto-attaches on Go, design, `gen/`, `Makefile`, chart, docs, and local Claude guidance paths. It owns repo-local Go conventions and access-check implementation truth (HTTP-over-NATS wrapper, centralized subject constants, unordered-response semantics, my-grants direct tuple reads, and the do-not-publish-index/access-mutation rule).
+> - Local rule `.claude/rules/access-check-boundaries.md` codifies the consumer-service boundary. Keep it aligned with code and chart behavior.
+> - If the central plugin is missing, install with `/plugin marketplace add linuxfoundation/lfx-skills` then `/plugin install lfx-skills@lfx-skills`.
+
 ## Quick Overview
 
 - **Purpose**: Bulk access checks for resource-action pairs
 - **Framework**: Go with Goa v3 (API-first design)
-- **Authentication**: JWT tokens from Heimdall
-- **Message Queue**: NATS for async processing; fga-sync evaluates permissions
+- **Authentication**: Heimdall-issued JWT validation through JWKS
+- **Messaging**: NATS request/reply against `lfx-v2-fga-sync`; this service never publishes index or tuple-mutation messages
 - **Deployment**: Kubernetes with Helm charts
+
+## Agent Guidance
+
+This service is a **consumer wrapper** over the access-check contract owned by `lfx-v2-fga-sync`. It owns its HTTP surface (see `docs/access-check-contract.md`) and nothing else. Tuple semantics, the OpenFGA model, cache behavior, and the canonical request/reply envelope live in `lfx-v2-fga-sync/docs/fga-sync-contract.md`. Deployed values and chart pins live in `lfx-v2-argocd`.
+
+Repo-owned guidance:
+
+- `.claude/skills/access-check-dev/SKILL.md` for repo-local Go, Goa, chart, contract-doc, and access-check implementation truth.
+- `.claude/skills/access-check-dev/references/goa-patterns.md` for access-check Goa methods and local deviations.
+- `.claude/skills/access-check-dev/references/nats-messaging.md` for the subject set and request/reply call shape.
+- `.claude/rules/access-check-boundaries.md` for the consumer-service boundary.
+- `docs/access-check-contract.md` for the authoritative HTTP API contract.
+- `docs/service-helm-chart.md` for this repo's chart interface.
 
 ## Architecture
 
@@ -26,7 +46,7 @@ lfx-v2-access-check/
 │   ├── access-svc.go              # Service design & endpoints
 │   └── types.go                   # Shared type definitions
 │
-├── gen/                           # Generated code (Goa) — do not edit
+├── gen/                           # Generated code (Goa), do not edit
 │   ├── access_svc/                # Service interfaces
 │   └── http/                      # HTTP transport layer
 │
@@ -119,34 +139,10 @@ make help             # Show all available targets
 
 ## API
 
-### Access Check
-
-Version is passed as a query parameter (`?v=1`), not in the request body.
-
-```http
-POST /access-check?v=1
-Authorization: Bearer <JWT_TOKEN>
-Content-Type: application/json
-
-{
-  "requests": ["project:a27394a3-7a6c-4d0f-9e0f-692d8753924f#auditor", "committee:b3c72e18-1a2b-4c3d-8e9f-123456789abc#writer"]
-}
-```
-
-Response (results are unordered — match on `object#relation@user` prefix):
-
-```json
-{
-  "results": ["project:a27394a3-7a6c-4d0f-9e0f-692d8753924f#auditor@user:auth0|alice\ttrue", "committee:b3c72e18-1a2b-4c3d-8e9f-123456789abc#writer@user:auth0|alice\tfalse"]
-}
-```
-
-### Health Checks
-- `GET /livez` - Liveness probe
-- `GET /readyz` - Readiness probe
-
-### OpenAPI Spec
-Available at `/_access-check/openapi.json`, `openapi.yaml`, `openapi3.json`, `openapi3.yaml`.
+The full API contract (request/response shape, unordered-response caveat,
+error mapping, timeout semantics, health checks, OpenAPI spec paths) lives in
+[`docs/access-check-contract.md`](docs/access-check-contract.md). Read that
+file before changing the HTTP surface.
 
 ## Deployment
 
@@ -161,44 +157,18 @@ docker run -p 8080:8080 ghcr.io/linuxfoundation/lfx-v2-access-check/lfx-access-c
 make helm-install
 ```
 
-## Service Architecture
-
-### Core Components
-
-1. **HTTP Server** (`cmd/lfx-access-check/`)
-   - Goa-based REST API server
-   - JWT authentication middleware
-   - Request ID tracking
-   - Structured logging
-
-2. **Access Service** (`internal/service/`)
-   - Core business logic
-   - JWT token validation
-   - NATS message publishing
-   - Response aggregation
-
-3. **Infrastructure Layer** (`internal/infrastructure/`)
-   - **Auth Repository**: Heimdall JWT validation
-   - **Messaging Repository**: NATS communication
-   - **Config**: Environment-based configuration
-
-4. **Domain Contracts** (`internal/domain/contracts/`)
-   - Shared data structures
-   - JWT claims modeling
-   - Service interfaces
-
 ## Testing
 
 ### Test Structure
 - **Unit Tests**: Service layer, infrastructure, configuration, middleware
-- **Integration Tests**: API endpoints with mock dependencies — no external services required
+- **Integration Tests**: API endpoints with mock dependencies, no external services required
 
 ### Running Tests
 ```bash
 # Unit tests
 make test
 
-# Integration tests (uses mocks — no external services needed)
+# Integration tests (uses mocks, no external services needed)
 go test -v ./test/integration/
 
 # Specific package tests
@@ -230,10 +200,8 @@ make test-coverage
 ## Monitoring & Observability
 
 ### Logging
-- **Structured Logging**: JSON format with consistent fields
-- **Request Tracking**: Unique request IDs for correlation
-- **Log Levels**: DEBUG, INFO, WARN, ERROR
-- **Context Propagation**: Request context through service layers
+
+Repo-owned logger discipline (slog, OpenTelemetry-aware fields, request-id and principal context propagation, log levels) lives in path-scoped `access-check-dev` guidance.
 
 ### Health Checks
 - **Liveness Probe**: `/livez` - Service basic health

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,7 @@ make test-coverage
 
 ### Integration Test Files
 - `access_check_test.go` - Tests access check endpoint with JWT validation
+- `my_grants_test.go` - Tests my-grants endpoint with JWT validation
 - `health_test.go` - Tests health check endpoints (/livez, /readyz)
 - `plaintext_test.go` - Tests plaintext response handling
 - `mocks.go` - Mock auth and messaging repositories

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 ![License](https://img.shields.io/badge/License-MIT-blue.svg)
 ![Go Version](https://img.shields.io/badge/Go-1.24+-00ADD8?logo=go)
 
-An access check service for the LFX Self-Service platform, providing centralized authorization and permission management across LFX services.
+An HTTP access-check wrapper for the LFX Self-Service platform. It validates Heimdall-issued JWTs, forwards access-check requests to `lfx-v2-fga-sync` over NATS request/reply, and returns the resulting permission decisions.
 
 ## Key Features
 
 - **Bulk Access Checks**: Process multiple resource-action permission checks in a single HTTP request
 - **JWT Authentication**: Secure authentication using Heimdall-issued JWT tokens
-- **Real-time Processing**: Asynchronous message processing via NATS, evaluated by fga-sync
+- **Real-time Processing**: Synchronous NATS request/reply calls evaluated by fga-sync
 - **Cloud Native**: Kubernetes-ready with Helm charts for easy deployment
 
 ## Architecture Overview
@@ -29,7 +29,7 @@ graph TB
     end
 
     subgraph "Platform Infrastructure"
-        N[NATS<br/>Message Queue]
+        N[NATS<br/>Request/Reply]
         FGA[fga-sync<br/>Permission Evaluator]
     end
 
@@ -38,7 +38,7 @@ graph TB
     AC --> AS
     AC --> HE
 
-    AS -->|publish bulk access check| N
+    AS -->|request bulk access check| N
     N -->|evaluate permissions| FGA
     FGA -->|return results| N
     N -->|authorization results| AS
@@ -52,17 +52,17 @@ sequenceDiagram
     participant Traefik as Traefik Gateway
     participant Heimdall as Heimdall Access Decision
     participant AccessCheck as Access Check Service
-    participant NATS as NATS Queue
+    participant NATS as NATS Request/Reply
     participant FGASync as fga-sync
 
     Client->>Traefik: POST /access-check?v=1<br />with Bearer JWT and resource list
-    Traefik->>Heimdall: Validate JWT & authorize
-    Heimdall-->>Traefik: Auth success
+    Traefik->>Heimdall: Authenticate caller and create service JWT
+    Heimdall-->>Traefik: Auth success with JWT
     Traefik->>AccessCheck: Forward authenticated request
 
-    AccessCheck->>AccessCheck: Extract principal from JWT
+    AccessCheck->>AccessCheck: Validate JWT and extract principal
     AccessCheck->>AccessCheck: Build resource-action pairs
-    AccessCheck->>NATS: Publish bulk access check
+    AccessCheck->>NATS: Request bulk access check
 
     NATS->>FGASync: Deliver check request
     FGASync->>FGASync: Evaluate permissions in OpenFGA
@@ -81,9 +81,9 @@ sequenceDiagram
 
 - **Go**: 1.24.0+
 - **Docker**: For containerized deployment
-- **NATS**: Message queue for service communication
-- **fga-sync**: Permission evaluator (processes access check messages from NATS)
-- **Heimdall**: JWT authentication provider
+- **NATS**: Request/reply transport for access-check calls
+- **fga-sync**: Permission evaluator with responders for `lfx.access_check.request` and `lfx.access_check.read_tuples`
+- **Heimdall**: Authentication provider and JWT finalizer
 
 ### Local Development
 
@@ -135,12 +135,16 @@ The service is configured via environment variables:
 | `HOST` | Server host address | `0.0.0.0` |
 | `PORT` | Server port | `8080` |
 | `DEBUG` | Enable debug logging | `false` |
+| `LOG_LEVEL` | Structured log level (`debug`, `info`, `warn`) | `debug` |
+| `LOG_ADD_SOURCE` | Include source file data in structured logs | `false` |
 | `JWKS_URL` | Heimdall JWKS endpoint | `http://heimdall:4457/.well-known/jwks` |
 | `AUDIENCE` | JWT audience | `lfx-v2-access-check` |
 | `ISSUER` | JWT issuer | `heimdall` |
 | `NATS_URL` | NATS server URL | `nats://nats:4222` |
 
 ## API Reference
+
+> **Source of truth:** [`docs/access-check-contract.md`](docs/access-check-contract.md) is authoritative for the HTTP surface (request, response, error mapping, timeout semantics, OpenAPI paths). The snippets below are a convenience overview; if they ever drift from the contract doc, the contract doc wins.
 
 ### Check Access
 
@@ -174,6 +178,17 @@ Content-Type: application/json
 
 Each result is a tab-separated string: `object#relation@user\ttrue` or `object#relation@user\tfalse`. The resource-action pair format is `{type}:{id}#{relation}`.
 
+### My Grants
+
+```
+GET /my-grants?v=1&object_type=project
+Authorization: Bearer <JWT_TOKEN>
+```
+
+Returns direct grants for the caller by object type, via fga-sync's
+`lfx.access_check.read_tuples` request/reply contract. It does not expand
+inherited access from parent resources.
+
 ### Health Endpoints
 
 - `GET /livez` — Liveness probe (basic service health)
@@ -201,7 +216,7 @@ The service serves its own OpenAPI spec at:
 2. **Access Service** (`internal/service/`)
    - Core business logic
    - JWT token validation
-   - NATS message publishing
+   - NATS request/reply communication
    - Response aggregation
 
 3. **Infrastructure Layer** (`internal/infrastructure/`)

--- a/docs/access-check-contract.md
+++ b/docs/access-check-contract.md
@@ -1,0 +1,115 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# Access Check Contract
+
+This is the authoritative reference for the HTTP API exposed by
+`lfx-v2-access-check`. The service is a thin HTTP wrapper around
+`lfx-v2-fga-sync`'s access-check request/reply subjects.
+
+## Endpoint
+
+### `POST /access-check`
+
+```http
+POST /access-check?v=1
+Authorization: Bearer <JWT_TOKEN>
+Content-Type: application/json
+
+{
+  "requests": [
+    "project:a27394a3-7a6c-4d0f-9e0f-692d8753924f#auditor",
+    "committee:b3c72e18-1a2b-4c3d-8e9f-123456789abc#writer"
+  ]
+}
+```
+
+The API version is passed as the `?v=1` query parameter, **not** in the
+request body. Every entry in `requests` is a `object#relation` token. The
+service appends the authenticated `@user:{principal}` suffix from the validated
+Heimdall JWT before forwarding to fga-sync. Relationship-token semantics are
+owned by fga-sync; this service does not define the OpenFGA model.
+
+## Response
+
+```json
+{
+  "results": [
+    "project:a27394a3-7a6c-4d0f-9e0f-692d8753924f#auditor@user:auth0|alice\ttrue",
+    "committee:b3c72e18-1a2b-4c3d-8e9f-123456789abc#writer@user:auth0|alice\tfalse"
+  ]
+}
+```
+
+### Unordered-response caveat
+
+**`results` order is not guaranteed.** fga-sync returns cached hits first and
+fresh OpenFGA checks afterward, so callers must match on the full
+`object#relation@user` prefix of each line, not by index. This is inherited
+from the underlying NATS contract documented in
+`lfx-v2-fga-sync/docs/fga-sync-contract.md`.
+
+Lines are tab-delimited: `{object#relation@user}\t{true|false}`.
+
+### `GET /my-grants`
+
+```http
+GET /my-grants?v=1&object_type=project
+Authorization: Bearer <JWT_TOKEN>
+```
+
+Returns direct OpenFGA tuples for the authenticated caller and requested object
+type. This is backed by `lfx.access_check.read_tuples`; inherited access through
+parent resources is not expanded.
+
+```json
+{
+  "grants": [
+    "project:a27394a3-7a6c-4d0f-9e0f-692d8753924f#writer@user:auth0|alice"
+  ]
+}
+```
+
+## Error Mapping
+
+| HTTP status | Cause |
+| --- | --- |
+| 400 Bad Request | Goa request validation failure: malformed JSON, missing required `Authorization` header, missing/unsupported `v`, empty `requests`, or invalid/missing `object_type` for `/my-grants` |
+| 401 Unauthorized | JWT is present but expired, invalid, or fails JWKS validation |
+| 500 Internal Server Error | Unexpected local or upstream response shape: auth claim type mismatch, JSON marshal/unmarshal failure, or malformed access-check reply |
+| 503 Service Unavailable | NATS request/reply failure or timeout, read-tuples backend error, or readiness dependency failure |
+
+The service emits only the four statuses above (per `design/access-svc.go`). There is no 403 path in this service. The Helm RuleSet authenticates callers with Heimdall and uses `allow_all`; permission decisions are returned as `true`/`false` or direct-grant data, not as gateway authorization failures.
+
+The service never returns a partial-success body; either every request was
+evaluated (200) or the call fails. Individual `false` results are normal
+denial responses, not errors.
+
+## Timeout Semantics
+
+The service issues a single NATS request to either `lfx.access_check.request`
+or `lfx.access_check.read_tuples` with a bounded timeout (default 15 seconds,
+`DefaultNATSTimeout` in `pkg/constants/messaging.go`). On timeout the HTTP
+response is 503 Service Unavailable with a log line, not a partial reply.
+
+Callers should set their own client-side timeout above the service's request
+timeout to allow the error path to propagate.
+
+## Health Checks
+
+- `GET /livez`: liveness probe; returns 200 if the service process is up.
+- `GET /readyz`: readiness probe; returns 200 only when both NATS and the
+  Heimdall JWKS endpoint are reachable.
+
+## OpenAPI Spec
+
+Available at `/_access-check/openapi.json`, `openapi.yaml`, `openapi3.json`,
+`openapi3.yaml`.
+
+## Upstream Contract
+
+The underlying NATS request/reply contract (envelope, batch semantics,
+direct-tuple reads, caching, model boundaries) is owned by `lfx-v2-fga-sync`.
+Read:
+
+`lfx-v2-fga-sync/docs/fga-sync-contract.md`

--- a/docs/service-helm-chart.md
+++ b/docs/service-helm-chart.md
@@ -1,0 +1,43 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# Service Helm Chart
+
+This document owns access-check-specific chart behavior. Shared chart
+conventions live in `lfx-v2-helm`; deployed values and chart pins live in
+`lfx-v2-argocd`.
+
+## Chart Shape
+
+- **Chart path**: `charts/lfx-v2-access-check/`.
+- **Service type**: thin HTTP Goa wrapper around fga-sync request/reply access
+  checks. It owns no resource data, no NATS KV bucket, no tuple publishing, and
+  no ExternalSecret.
+- **Container env**: `PORT`, `HOST`, `DEBUG`, `AUDIENCE`, `ISSUER`, `NATS_URL`,
+  and `JWKS_URL`, plus optional `app.extraEnv` and OpenTelemetry env rendered
+  from `app.otel`.
+- **NATS dependency**: fga-sync must be running responders for
+  `lfx.access_check.request` and `lfx.access_check.read_tuples`.
+- **Health probes**: liveness uses `/livez`; readiness and startup use
+  `/readyz`, which checks NATS and the Heimdall JWKS endpoint.
+
+## Routing
+
+- **HTTPRoute paths**: exact `/access-check`, prefix `/access-check/`, prefix
+  `/_access-check/`, and exact `/my-grants`.
+- **RuleSet**:
+  - `POST /access-check`: `oidc`, `allow_all`, `create_jwt`.
+  - `GET /my-grants`: `oidc`, `allow_all`, `create_jwt`.
+  - `GET|HEAD|OPTIONS /_access-check/*`: `oidc` or anonymous, `allow_all`,
+    `create_jwt`.
+
+Do not add `openfga_check` authorizer rules here. This service's job is to
+return access decisions from fga-sync; it is not protecting a resource of its
+own in Heimdall.
+
+## Local Values
+
+`charts/lfx-v2-access-check/values.local.example.yaml` only overrides the image
+repository, tag, and pull policy for local chart rendering or install. The
+gitignored `values.local.yaml` can add developer-only overrides without
+changing the committed chart interface.


### PR DESCRIPTION
## Summary

Part of the LFX developer-AI **fan-out** ([LFXV2-2015](https://linuxfoundation.atlassian.net/browse/LFXV2-2015)): repo-specific AI guidance moves out of the central `lfx-skills` plugin and into each owning repo, beside the code it describes. This PR lands this repo's share of that work.

> ## 📖 Read these first (they explain this PR)
>
> This is one of ~15 coordinated fan-out PRs. **Before reviewing, please read the three short docs that explain the whole change** — they are the source of truth for the model and for what landed where:
>
> | Doc | What it gives you |
> |---|---|
> | 👉 **[Fan-out architecture](https://docs.google.com/document/d/10eZy8n5xgU7LratcntjkUjGSZmuHpO0xUkskJbJPkfc/edit?usp=sharing)** | The end-to-end model and the why behind it: the central-vs-repo split, the review lifecycle, and the per-repo tradeoffs. **Start here.** |
> | 👉 **[Fan-out owner guidance](https://docs.google.com/document/d/15MPhvRh4Ifxr7VZnIiD2xxoWy_mjv1naeKW4IQLa3iU/edit?usp=sharing)** | The new ownership model, central-vs-repo boundaries, and the review-lifecycle expectations. |
> | 👉 **[Rollout inventory](https://docs.google.com/document/d/1kqhRjzDz0_7a4z4nRZMyD-yQWL6ZEZC_dztz8yhb4K0/edit?usp=sharing)** | Exactly what moved out of central and what landed in each repo — find this repo's section for the full scope. |
>
> Tracking epic: **[LFXV2-2015](https://linuxfoundation.atlassian.net/browse/LFXV2-2015)**.

## Why — the new architecture

**Central finds the right owner and explains the shared platform; each repo explains itself.** The central `lfx-skills` plugin keeps only genuinely-central surfaces: cross-repo routing, platform architecture, shared integration guidance, global workflows, and reviewer-agent distribution. Repo-specific implementation truth — conventions, generated-code boundaries, endpoint workflows, contracts, and chart defaults — now lives in the owning repo, where it changes together with the contracts, tests, and charts it describes.

This fixes the drift problem a central rulebook creates: it either grows until it contains repo-specific exceptions for every service, or stays short and goes stale. Where a repo has a review lifecycle, its repo-specific reviewer agents are packaged centrally (so they're available by name in any Claude runtime) but read **evidence this repo owns** — its `CLAUDE.md`, skills, rules, contracts, checklists, and review KB.

## Changes in this repo

- Repo-local skill: `access-check-dev` (the HTTP-over-NATS wrapper pattern, centralized subject constants, unordered response semantics, my-grants direct tuple reads, and the do-not-publish-index/access-mutation rule).
- Repo-local rule: `access-check-boundaries`.
- Owned docs: `docs/access-check-contract.md` and `docs/service-helm-chart.md`.
- `CLAUDE.md` routes platform/topology questions to the central skills; tuple/access-check semantics defer to `lfx-v2-fga-sync`.

> This branch is current with `main`.

### Kept current with `main` (2026-06-11)

This branch was re-merged with the latest `main` and the guidance re-audited against the current code. Main's movement was observability-only. One fix landed: the request-context section now names the actual context keys the middleware uses.

## Reference links

- **Jira epic:** [LFXV2-2015](https://linuxfoundation.atlassian.net/browse/LFXV2-2015)
- **Owner guidance** — steady-state ownership + review lifecycle: [Owner guidance (Google Doc)](https://docs.google.com/document/d/15MPhvRh4Ifxr7VZnIiD2xxoWy_mjv1naeKW4IQLa3iU/edit?usp=sharing)
- **Rollout inventory** — per-repo "what changed": [Rollout inventory (Google Doc)](https://docs.google.com/document/d/1kqhRjzDz0_7a4z4nRZMyD-yQWL6ZEZC_dztz8yhb4K0/edit?usp=sharing)
- **Fan-out architecture** — the model and the why: [Fan-out architecture (Google Doc)](https://docs.google.com/document/d/10eZy8n5xgU7LratcntjkUjGSZmuHpO0xUkskJbJPkfc/edit?usp=sharing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LFXV2-2015]: https://linuxfoundation.atlassian.net/browse/LFXV2-2015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LFXV2-2015]: https://linuxfoundation.atlassian.net/browse/LFXV2-2015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
