### PR TITLE
Fix Datadog trace resource names

### DIFF
--- a/cmd/lfx-access-check/server.go
+++ b/cmd/lfx-access-check/server.go
@@ -55,6 +55,32 @@ func handleHTTPServer(ctx context.Context, cfg *config.Config, endpoints *access
 	var mux goahttp.MiddlewareMuxer
 	{
 		mux = goahttp.NewMuxer()
+		// Register route-tagging middleware inside chi's routing chain so that
+		// http.route is set on the OTel span after chi has matched the route pattern.
+		// The span name is also updated here to avoid high-cardinality names from
+		// using raw URL paths (which contain actual path parameter values).
+		// Must be registered before Mount calls per chi convention.
+		// Reads RoutePattern after next.ServeHTTP because chi populates the pattern
+		// during routing (inside ServeHTTP), not before.
+		mux.Use(func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer func() {
+					rctx := chi.RouteContext(r.Context())
+					if rctx != nil {
+						routePattern := rctx.RoutePattern()
+						if routePattern != "" {
+							if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
+								labeler.Add(semconv.HTTPRoute(routePattern))
+							}
+							span := trace.SpanFromContext(r.Context())
+							span.SetAttributes(semconv.HTTPRoute(routePattern))
+							span.SetName(r.Method + " " + routePattern)
+						}
+					}
+				}()
+				next.ServeHTTP(w, r)
+			})
+		})
 		if cfg.Debug {
 			// Mount debug endpoints when in debug mode
 			debug.MountPprofHandlers(debug.Adapt(mux))
@@ -66,14 +92,14 @@ func handleHTTPServer(ctx context.Context, cfg *config.Config, endpoints *access
 	var accessSvcServer *accesssvcsvr.Server
 	{
 		eh := errorHandler(ctx)
-		
+
 		// Setup file system for OpenAPI files
 		koDatapath := os.Getenv("KO_DATA_PATH")
 		if koDatapath == "" {
 			koDatapath = "."
 		}
 		koHttpDir := http.Dir(koDatapath)
-		
+
 		accessSvcServer = accesssvcsvr.New(
 			endpoints,
 			mux,
@@ -87,31 +113,6 @@ func handleHTTPServer(ctx context.Context, cfg *config.Config, endpoints *access
 			koHttpDir, // file system for openapi3.yaml
 		)
 	}
-
-	// Register route-tagging middleware inside chi's routing chain so that
-	// http.route is set on the OTel span after chi has matched the route pattern.
-	// The span name is also updated here to avoid high-cardinality names from
-	// using raw URL paths (which contain actual path parameter values).
-	// Must be registered before Mount calls per chi convention.
-	// Reads RoutePattern after next.ServeHTTP because chi populates the pattern
-	// during routing (inside ServeHTTP), not before.
-	mux.Use(func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			defer func() {
-				rctx := chi.RouteContext(r.Context())
-				if rctx != nil {
-					routePattern := rctx.RoutePattern()
-					if routePattern != "" {
-						if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
-							labeler.Add(semconv.HTTPRoute(routePattern))
-						}
-						trace.SpanFromContext(r.Context()).SetName(r.Method + " " + routePattern)
-					}
-				}
-			}()
-			next.ServeHTTP(w, r)
-		})
-	})
 
 	// Mount all endpoints
 	accesssvcsvr.Mount(mux, accessSvcServer)

--- a/cmd/lfx-access-check/server.go
+++ b/cmd/lfx-access-check/server.go
@@ -11,16 +11,19 @@ import (
 	"os"
 	"sync"
 
+	"github.com/go-chi/chi/v5"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
+	"go.opentelemetry.io/otel/trace"
+	"goa.design/clue/debug"
+	goahttp "goa.design/goa/v3/http"
+
 	accesssvc "github.com/linuxfoundation/lfx-v2-access-check/gen/access_svc"
 	accesssvcsvr "github.com/linuxfoundation/lfx-v2-access-check/gen/http/access_svc/server"
 	"github.com/linuxfoundation/lfx-v2-access-check/internal/container"
 	"github.com/linuxfoundation/lfx-v2-access-check/internal/infrastructure/config"
 	"github.com/linuxfoundation/lfx-v2-access-check/internal/middleware"
 	"github.com/linuxfoundation/lfx-v2-access-check/pkg/constants"
-
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
-	"goa.design/clue/debug"
-	goahttp "goa.design/goa/v3/http"
 )
 
 // StartServer initializes and starts the access check server following LFX pattern
@@ -49,7 +52,7 @@ func StartServer(ctx context.Context, cfg *config.Config) error {
 // handleHTTPServer follows exact LFX query service pattern for server setup
 func handleHTTPServer(ctx context.Context, cfg *config.Config, endpoints *accesssvc.Endpoints, cont *container.Container) error {
 	// Build the service HTTP request multiplexer
-	var mux goahttp.Muxer
+	var mux goahttp.MiddlewareMuxer
 	{
 		mux = goahttp.NewMuxer()
 		if cfg.Debug {
@@ -84,6 +87,29 @@ func handleHTTPServer(ctx context.Context, cfg *config.Config, endpoints *access
 			koHttpDir, // file system for openapi3.yaml
 		)
 	}
+
+	// Register route-tagging middleware inside chi's routing chain so that
+	// http.route is set on the OTel span after chi has matched the route pattern.
+	// The span name is also updated here to avoid high-cardinality names from
+	// using raw URL paths (which contain actual path parameter values).
+	// Must be registered before Mount calls per chi convention.
+	// Reads RoutePattern after next.ServeHTTP because chi populates the pattern
+	// during routing (inside ServeHTTP), not before.
+	mux.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r)
+			rctx := chi.RouteContext(r.Context())
+			if rctx != nil {
+				routePattern := rctx.RoutePattern()
+				if routePattern != "" {
+					if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
+						labeler.Add(semconv.HTTPRoute(routePattern))
+					}
+					trace.SpanFromContext(r.Context()).SetName(r.Method + " " + routePattern)
+				}
+			}
+		})
+	})
 
 	// Mount all endpoints
 	accesssvcsvr.Mount(mux, accessSvcServer)

--- a/cmd/lfx-access-check/server.go
+++ b/cmd/lfx-access-check/server.go
@@ -97,17 +97,19 @@ func handleHTTPServer(ctx context.Context, cfg *config.Config, endpoints *access
 	// during routing (inside ServeHTTP), not before.
 	mux.Use(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			next.ServeHTTP(w, r)
-			rctx := chi.RouteContext(r.Context())
-			if rctx != nil {
-				routePattern := rctx.RoutePattern()
-				if routePattern != "" {
-					if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
-						labeler.Add(semconv.HTTPRoute(routePattern))
+			defer func() {
+				rctx := chi.RouteContext(r.Context())
+				if rctx != nil {
+					routePattern := rctx.RoutePattern()
+					if routePattern != "" {
+						if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
+							labeler.Add(semconv.HTTPRoute(routePattern))
+						}
+						trace.SpanFromContext(r.Context()).SetName(r.Method + " " + routePattern)
 					}
-					trace.SpanFromContext(r.Context()).SetName(r.Method + " " + routePattern)
 				}
-			}
+			}()
+			next.ServeHTTP(w, r)
 		})
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/aws/smithy-go v1.22.3 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dimfeld/httppath v0.0.0-20170720192232-ee938bf73598 // indirect
-	github.com/go-chi/chi/v5 v5.2.4 // indirect
+	github.com/go-chi/chi/v5 v5.2.4
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/gohugoio/hashstructure v0.6.0 // indirect
 	github.com/google/uuid v1.6.0
@@ -54,7 +54,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.40.0
-	go.opentelemetry.io/otel/trace v1.40.0 // indirect
+	go.opentelemetry.io/otel/trace v1.40.0
 	goa.design/clue v1.2.1
 	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/mod v0.32.0 // indirect


### PR DESCRIPTION
## Summary

- Add chi route-tagging middleware to set `http.route` on OTel spans after chi matches the route pattern
- Update `trace.SpanFromContext().SetName()` with the matched route pattern so Datadog shows `GET /api/v1/access/{id}` instead of just `GET`
- Change `var mux goahttp.Muxer` to `goahttp.MiddlewareMuxer` to expose the `Use()` method
- Promote `chi/v5` and `otel/trace` from indirect to direct dependencies in `go.mod`

Fixes low-cardinality Datadog trace resource names across the service by reading the chi route pattern post-`ServeHTTP` (the only point at which chi has populated it).

JIRA: [LFXV2-1935](https://linuxfoundation.atlassian.net/browse/LFXV2-1935)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-1935]: https://linuxfoundation.atlassian.net/browse/LFXV2-1935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ