### PR TITLE
fix(chart): standardize tracesSamplerArg comment

### DIFF
--- a/charts/lfx-v2-access-check/values.yaml
+++ b/charts/lfx-v2-access-check/values.yaml
@@ -92,9 +92,9 @@ app:
     # "parentbased_always_off", "parentbased_traceidratio".
     # When empty, the application defaults to parentbased_traceidratio.
     tracesSampler: ""
-    # tracesSamplerArg is the argument for the traces sampler (e.g., sampling ratio).
-    # Used by ratio-based samplers: "traceidratio" and "parentbased_traceidratio".
-    # When empty, defaults to "1.0" (sample all).
+    # tracesSamplerArg specifies the OTEL_TRACES_SAMPLER_ARG (sampler ratio or parent_sampler_arg).
+    # Used by "traceidratio" and "parentbased_traceidratio" samplers (defaults to 1.0 if empty).
+    # (default: "")
     tracesSamplerArg: ""
     # metricsExporter specifies the metrics exporter: "otlp" or "none"
     # (default: "none")


### PR DESCRIPTION
## Summary

- Standardizes the `tracesSamplerArg` Helm chart comment to match the canonical wording from `lfx-v2-email-service`
- Rewrites the 3-line comment to the 2-line canonical form with `(default: "")` footer

## Test plan
- [ ] Comment in `values.yaml` matches canonical format

🤖 Generated with [Claude Code](https://claude.com/claude-code)