### PR TITLE
refactor(service): split AccessService into Goa adapter + AccessCheckClient [LFXV2-2983]

### DIFF
--- a/internal/service/access_check_client.go
+++ b/internal/service/access_check_client.go
@@ -1,0 +1,163 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/linuxfoundation/lfx-v2-access-check/internal/domain/contracts"
+	"github.com/linuxfoundation/lfx-v2-access-check/pkg/constants"
+)
+
+// AccessCheckClient handles the NATS protocol for access checking and tuple reading.
+// It owns the message build/parse logic and the two NATS subjects, with no knowledge
+// of HTTP, Goa types, or authentication.
+type AccessCheckClient struct {
+	messagingRepo contracts.MessagingRepository
+}
+
+// NewAccessCheckClient creates a new AccessCheckClient backed by the given messaging repository.
+func NewAccessCheckClient(messagingRepo contracts.MessagingRepository) *AccessCheckClient {
+	return &AccessCheckClient{messagingRepo: messagingRepo}
+}
+
+// HealthCheck checks the messaging repository health, returning ErrMessagingRepoNotInit
+// if the repository was never provided.
+func (c *AccessCheckClient) HealthCheck(ctx context.Context) error {
+	if c.messagingRepo == nil {
+		return constants.ErrMessagingRepoNotInit
+	}
+	return c.messagingRepo.HealthCheck(ctx)
+}
+
+// CheckAccess sends resource-action pairs to fga-sync via NATS and returns the
+// newline-delimited result lines in the same order as the request.
+// principal must be non-empty; empty resource strings are skipped.
+func (c *AccessCheckClient) CheckAccess(ctx context.Context, principal string, resources []string) ([]string, error) {
+	if principal == "" {
+		return nil, constants.ErrPrincipalRequired
+	}
+
+	if len(resources) == 0 {
+		return []string{}, nil
+	}
+
+	message := c.buildMessage(principal, resources)
+	if message == "" {
+		return []string{}, nil
+	}
+
+	responseData, err := c.messagingRepo.Request(ctx, constants.AccessCheckSubject, []byte(message), constants.DefaultNATSTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("NATS request to subject %s failed: %w", constants.AccessCheckSubject, err)
+	}
+
+	return c.parseResponse(responseData)
+}
+
+// ReadTuples fetches the direct OpenFGA tuples for a principal via NATS.
+func (c *AccessCheckClient) ReadTuples(ctx context.Context, principal string, objectType string) ([]string, error) {
+	reqPayload, err := json.Marshal(readTuplesRequest{
+		User:       constants.UserTypePrefix + principal,
+		ObjectType: objectType,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to build read tuples request: %v", constants.ErrUnexpectedResponse, err)
+	}
+
+	responseData, err := c.messagingRepo.Request(ctx, constants.ReadTuplesSubject, reqPayload, constants.DefaultNATSTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("NATS request to subject %s failed: %w", constants.ReadTuplesSubject, err)
+	}
+
+	var resp readTuplesResponse
+	if err := json.Unmarshal(responseData, &resp); err != nil {
+		return nil, fmt.Errorf("%w: failed to parse read tuples response: %v", constants.ErrUnexpectedResponse, err)
+	}
+
+	if resp.Error != "" {
+		return nil, fmt.Errorf("message to subject %s failed with FGA error: %s", constants.ReadTuplesSubject, resp.Error)
+	}
+
+	if resp.Results == nil {
+		return []string{}, nil
+	}
+	return resp.Results, nil
+}
+
+// buildMessage constructs the newline-separated plaintext NATS payload for
+// access-check requests in the form "object#relation@user:principal".
+// Empty resource strings are skipped.
+func (c *AccessCheckClient) buildMessage(principal string, resources []string) string {
+	var builder strings.Builder
+
+	totalCapacity := 0
+	for _, resource := range resources {
+		if resource != "" {
+			// resource + "@user:" + principal + newline
+			totalCapacity += len(resource) + len(constants.UserRelationPrefix) + len(principal) + 1
+		}
+	}
+
+	if totalCapacity > 0 {
+		builder.Grow(totalCapacity)
+	}
+
+	for _, resource := range resources {
+		if resource == "" {
+			continue
+		}
+		builder.WriteString(resource)
+		builder.WriteString(constants.UserRelationPrefix)
+		builder.WriteString(principal)
+		builder.WriteByte('\n')
+	}
+
+	message := builder.String()
+	if len(message) > 0 && message[len(message)-1] == '\n' {
+		message = message[:len(message)-1]
+	}
+
+	return message
+}
+
+// parseResponse validates and splits the NATS access-check reply into result lines.
+// A space appearing in the first DefaultResponseSanityCheckBytes bytes indicates an
+// error message from fga-sync rather than a valid result payload.
+func (c *AccessCheckClient) parseResponse(responseData []byte) ([]string, error) {
+	topRange := constants.DefaultResponseSanityCheckBytes
+	if len(responseData) < topRange {
+		topRange = len(responseData)
+	}
+	if bytes.Contains(responseData[:topRange], []byte(" ")) {
+		return nil, fmt.Errorf("%w: response_preview=%q", constants.ErrUnexpectedResponse, string(responseData[:topRange]))
+	}
+
+	lines := bytes.Split(responseData, []byte("\n"))
+	results := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		results = append(results, string(line))
+	}
+	return results, nil
+}
+
+// readTuplesRequest is the JSON payload sent to fga-sync over NATS.
+type readTuplesRequest struct {
+	User       string `json:"user"`
+	ObjectType string `json:"object_type"`
+}
+
+// readTuplesResponse is the JSON response received from fga-sync over NATS.
+type readTuplesResponse struct {
+	Results []string `json:"results,omitempty"`
+	Error   string   `json:"error,omitempty"`
+}

--- a/internal/service/access_check_client.go
+++ b/internal/service/access_check_client.go
@@ -36,7 +36,13 @@ func (c *AccessCheckClient) HealthCheck(ctx context.Context) error {
 }
 
 // CheckAccess sends resource-action pairs to fga-sync via NATS and returns the
-// newline-delimited result lines in the same order as the request.
+// newline-delimited result lines.
+//
+// Important: result order is NOT guaranteed. fga-sync returns cached hits
+// before fresh OpenFGA checks, so callers must match each line by its
+// "object#relation@user" prefix, not by position. See
+// docs/access-check-contract.md for the full unordered-response caveat.
+//
 // principal must be non-empty; empty resource strings are skipped.
 func (c *AccessCheckClient) CheckAccess(ctx context.Context, principal string, resources []string) ([]string, error) {
 	if principal == "" {

--- a/internal/service/access_check_client_test.go
+++ b/internal/service/access_check_client_test.go
@@ -1,0 +1,307 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/linuxfoundation/lfx-v2-access-check/pkg/constants"
+)
+
+// ===== AccessCheckClient unit tests =====
+// These tests exercise the NATS protocol logic in isolation.
+// No Goa types are imported here; only the domain contracts and constants.
+
+func newTestClient(requestFunc func(ctx context.Context, subject string, data []byte, timeout time.Duration) ([]byte, error)) *AccessCheckClient {
+	return NewAccessCheckClient(&mockMessagingRepository{requestFunc: requestFunc})
+}
+
+// ----- CheckAccess -----
+
+func TestAccessCheckClient_CheckAccess_EmptyPrincipal(t *testing.T) {
+	client := NewAccessCheckClient(&mockMessagingRepository{})
+
+	_, err := client.CheckAccess(context.Background(), "", []string{"resource1"})
+	if err == nil {
+		t.Fatal("CheckAccess should fail with empty principal")
+	}
+	if !errors.Is(err, constants.ErrPrincipalRequired) {
+		t.Errorf("expected ErrPrincipalRequired, got %v", err)
+	}
+}
+
+func TestAccessCheckClient_CheckAccess_EmptyResources(t *testing.T) {
+	client := NewAccessCheckClient(&mockMessagingRepository{})
+
+	result, err := client.CheckAccess(context.Background(), "test-user", []string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty result for empty resources, got %d items", len(result))
+	}
+}
+
+func TestAccessCheckClient_CheckAccess_UnexpectedResponse(t *testing.T) {
+	client := newTestClient(func(_ context.Context, _ string, _ []byte, _ time.Duration) ([]byte, error) {
+		return []byte("error message here"), nil
+	})
+
+	_, err := client.CheckAccess(context.Background(), "test-user", []string{"resource1"})
+	if err == nil {
+		t.Fatal("CheckAccess should fail on space-containing response")
+	}
+	if !errors.Is(err, constants.ErrUnexpectedResponse) {
+		t.Errorf("expected ErrUnexpectedResponse, got %v", err)
+	}
+}
+
+func TestAccessCheckClient_CheckAccess_NATSFailure(t *testing.T) {
+	client := newTestClient(func(_ context.Context, _ string, _ []byte, _ time.Duration) ([]byte, error) {
+		return nil, errors.New("NATS connection failed")
+	})
+
+	_, err := client.CheckAccess(context.Background(), "test-user", []string{"resource1"})
+	if err == nil {
+		t.Fatal("expected error on NATS failure")
+	}
+	if !strings.Contains(err.Error(), "NATS request to subject") {
+		t.Errorf("expected NATS transport error, got %v", err)
+	}
+}
+
+func TestAccessCheckClient_CheckAccess_CorrectSubject(t *testing.T) {
+	var gotSubject string
+	client := newTestClient(func(_ context.Context, subject string, _ []byte, _ time.Duration) ([]byte, error) {
+		gotSubject = subject
+		return []byte("true\nfalse"), nil
+	})
+
+	_, err := client.CheckAccess(context.Background(), "alice", []string{"project:abc#viewer"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotSubject != constants.AccessCheckSubject {
+		t.Errorf("expected subject %q, got %q", constants.AccessCheckSubject, gotSubject)
+	}
+}
+
+// ----- ReadTuples -----
+
+func TestAccessCheckClient_ReadTuples_Success(t *testing.T) {
+	client := newTestClient(func(_ context.Context, subject string, _ []byte, _ time.Duration) ([]byte, error) {
+		if subject != constants.ReadTuplesSubject {
+			t.Errorf("unexpected NATS subject: %s", subject)
+		}
+		return []byte(`{"results":["project:abc#auditor@user:alice","committee:xyz#writer@user:alice"]}`), nil
+	})
+
+	results, err := client.ReadTuples(context.Background(), "alice", "project")
+	if err != nil {
+		t.Fatalf("ReadTuples failed: %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("expected 2 results, got %d", len(results))
+	}
+}
+
+func TestAccessCheckClient_ReadTuples_NilResultsNormalized(t *testing.T) {
+	client := newTestClient(func(_ context.Context, _ string, _ []byte, _ time.Duration) ([]byte, error) {
+		return []byte(`{}`), nil
+	})
+
+	results, err := client.ReadTuples(context.Background(), "alice", "project")
+	if err != nil {
+		t.Fatalf("ReadTuples failed: %v", err)
+	}
+	if results == nil {
+		t.Error("expected empty slice, got nil")
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestAccessCheckClient_ReadTuples_NATSFailure(t *testing.T) {
+	client := newTestClient(func(_ context.Context, _ string, _ []byte, _ time.Duration) ([]byte, error) {
+		return nil, errors.New("nats timeout")
+	})
+
+	_, err := client.ReadTuples(context.Background(), "alice", "project")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "NATS request to subject") {
+		t.Errorf("expected NATS transport error, got %v", err)
+	}
+}
+
+func TestAccessCheckClient_ReadTuples_UnmarshalFailure(t *testing.T) {
+	client := newTestClient(func(_ context.Context, _ string, _ []byte, _ time.Duration) ([]byte, error) {
+		return []byte(`not valid json`), nil
+	})
+
+	_, err := client.ReadTuples(context.Background(), "alice", "project")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, constants.ErrUnexpectedResponse) {
+		t.Errorf("expected ErrUnexpectedResponse, got %v", err)
+	}
+}
+
+func TestAccessCheckClient_ReadTuples_BackendError(t *testing.T) {
+	client := newTestClient(func(_ context.Context, _ string, _ []byte, _ time.Duration) ([]byte, error) {
+		return []byte(`{"error":"store not found"}`), nil
+	})
+
+	_, err := client.ReadTuples(context.Background(), "alice", "project")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "FGA error") {
+		t.Errorf("expected FGA error message, got %v", err)
+	}
+	if strings.Contains(err.Error(), "NATS request") {
+		t.Errorf("backend error should not look like a NATS transport error, got %v", err)
+	}
+}
+
+// ----- HealthCheck -----
+
+func TestAccessCheckClient_HealthCheck_NilRepo(t *testing.T) {
+	client := NewAccessCheckClient(nil)
+
+	err := client.HealthCheck(context.Background())
+	if err == nil {
+		t.Fatal("expected error for nil messaging repo")
+	}
+	if !errors.Is(err, constants.ErrMessagingRepoNotInit) {
+		t.Errorf("expected ErrMessagingRepoNotInit, got %v", err)
+	}
+}
+
+func TestAccessCheckClient_HealthCheck_Healthy(t *testing.T) {
+	client := NewAccessCheckClient(&mockMessagingRepository{})
+
+	if err := client.HealthCheck(context.Background()); err != nil {
+		t.Errorf("expected healthy, got %v", err)
+	}
+}
+
+// ----- buildMessage -----
+
+func TestAccessCheckClient_BuildMessage(t *testing.T) {
+	client := NewAccessCheckClient(&mockMessagingRepository{})
+
+	tests := []struct {
+		name      string
+		principal string
+		resources []string
+		expected  string
+	}{
+		{
+			name:      "empty resources",
+			principal: "user1",
+			resources: []string{},
+			expected:  "",
+		},
+		{
+			name:      "single resource",
+			principal: "user1",
+			resources: []string{"repo1"},
+			expected:  "repo1@user:user1",
+		},
+		{
+			name:      "multiple resources",
+			principal: "user1",
+			resources: []string{"repo1", "repo2"},
+			expected:  "repo1@user:user1\nrepo2@user:user1",
+		},
+		{
+			name:      "empty resource filtered out",
+			principal: "user1",
+			resources: []string{"repo1", "", "repo2"},
+			expected:  "repo1@user:user1\nrepo2@user:user1",
+		},
+		{
+			name:      "all empty resources",
+			principal: "user1",
+			resources: []string{"", "", ""},
+			expected:  "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := client.buildMessage(tc.principal, tc.resources)
+			if result != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, result)
+			}
+		})
+	}
+}
+
+// ----- parseResponse -----
+
+func TestAccessCheckClient_ParseResponse(t *testing.T) {
+	client := NewAccessCheckClient(&mockMessagingRepository{})
+
+	tests := []struct {
+		name         string
+		responseData []byte
+		expected     []string
+		expectError  bool
+	}{
+		{
+			name:         "valid response",
+			responseData: []byte("true\nfalse\ntrue"),
+			expected:     []string{"true", "false", "true"},
+		},
+		{
+			name:         "empty response",
+			responseData: []byte(""),
+			expected:     []string{},
+		},
+		{
+			name:         "response with empty lines",
+			responseData: []byte("true\n\nfalse\n"),
+			expected:     []string{"true", "false"},
+		},
+		{
+			name:         "response with spaces triggers error",
+			responseData: []byte("error message here"),
+			expectError:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := client.parseResponse(tc.responseData)
+
+			if tc.expectError {
+				if err == nil {
+					t.Fatal("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(result) != len(tc.expected) {
+				t.Fatalf("expected %d results, got %d", len(tc.expected), len(result))
+			}
+			for i, want := range tc.expected {
+				if result[i] != want {
+					t.Errorf("result[%d]: expected %q, got %q", i, want, result[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/service/access_service.go
+++ b/internal/service/access_service.go
@@ -5,9 +5,7 @@
 package service
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -19,38 +17,53 @@ import (
 	"goa.design/goa/v3/security"
 )
 
-// AccessService implements both domain logic and GOA service interfaces
-// This unified approach simplifies the architecture while maintaining clean separation
-// of infrastructure concerns through dependency injection
+// AccessService is a thin Goa adapter: it validates JWT tokens, delegates all
+// NATS protocol work to AccessCheckClient, and maps domain errors to Goa HTTP
+// error types. It owns no message-encoding logic.
 type AccessService struct {
-	authRepo      contracts.AuthRepository
-	messagingRepo contracts.MessagingRepository
+	authRepo contracts.AuthRepository
+	client   *AccessCheckClient
 }
 
-// NewAccessService creates a new unified access service
+// NewAccessService creates a new AccessService wired to the given repositories.
 func NewAccessService(authRepo contracts.AuthRepository, messagingRepo contracts.MessagingRepository) *AccessService {
 	return &AccessService{
-		authRepo:      authRepo,
-		messagingRepo: messagingRepo,
+		authRepo: authRepo,
+		client:   NewAccessCheckClient(messagingRepo),
 	}
 }
 
-// Verify interface compliance at compile time
+// Verify interface compliance at compile time.
 var (
 	_ accesssvc.Service = (*AccessService)(nil)
 	_ accesssvc.Auther  = (*AccessService)(nil)
 )
 
+// ===== Package-level helpers =====
+
+// claimsFromContext extracts HeimdallClaims injected by JWTAuth.
+func claimsFromContext(ctx context.Context) (*contracts.HeimdallClaims, bool) {
+	claims, ok := ctx.Value(constants.ClaimsContextKey).(*contracts.HeimdallClaims)
+	return claims, ok
+}
+
+// requireAPIVersion returns a non-nil error when version does not match the
+// single supported API version. Callers wrap the result in accesssvc.MakeBadRequest.
+func requireAPIVersion(version string) error {
+	if version != constants.SupportedAPIVersion {
+		return fmt.Errorf("%s: %s", constants.ErrMsgUnsupportedAPIVersion, version)
+	}
+	return nil
+}
+
 // ===== GOA Authentication Interface =====
 
-// JWTAuth implements the authorization logic for the JWT security scheme
+// JWTAuth implements the authorization logic for the JWT security scheme.
 func (s *AccessService) JWTAuth(ctx context.Context, token string, _ *security.JWTScheme) (context.Context, error) {
-	// Remove "Bearer " prefix if present
 	if after, ok := strings.CutPrefix(token, constants.BearerTokenPrefix); ok {
 		token = after
 	}
 
-	// Validate token using auth repository
 	claims, err := s.authRepo.ValidateToken(ctx, token)
 	if err != nil {
 		slog.ErrorContext(ctx, "JWT validation failed", "error", err)
@@ -60,28 +73,24 @@ func (s *AccessService) JWTAuth(ctx context.Context, token string, _ *security.J
 		return nil, accesssvc.MakeUnauthorized(constants.ErrInvalidToken)
 	}
 
-	// Add claims to context for use in endpoints
 	ctx = context.WithValue(ctx, constants.ClaimsContextKey, claims)
-
 	slog.DebugContext(ctx, "JWT validation successful", "principal", claims.Principal)
 	return ctx, nil
 }
 
-// ===== GOA Service Interface Implementation =====
+// ===== GOA Service Interface =====
 
-// CheckAccess implements the access check endpoint with embedded business logic
+// CheckAccess validates the request and delegates to AccessCheckClient.
 func (s *AccessService) CheckAccess(ctx context.Context, p *accesssvc.CheckAccessPayload) (*accesssvc.CheckAccessResult, error) {
-	// Extract claims from context
-	claims, ok := ctx.Value(constants.ClaimsContextKey).(*contracts.HeimdallClaims)
+	claims, ok := claimsFromContext(ctx)
 	if !ok {
 		slog.ErrorContext(ctx, "Failed to get claims from context")
 		return nil, accesssvc.MakeUnauthorized(constants.ErrInvalidAuthContext)
 	}
 
-	// Validate payload
-	if p.Version != constants.SupportedAPIVersion {
+	if err := requireAPIVersion(p.Version); err != nil {
 		slog.WarnContext(ctx, "Unsupported API version", "version", p.Version)
-		return nil, accesssvc.MakeBadRequest(fmt.Errorf("%s: %s", constants.ErrMsgUnsupportedAPIVersion, p.Version))
+		return nil, accesssvc.MakeBadRequest(err)
 	}
 
 	if len(p.Requests) == 0 {
@@ -89,8 +98,7 @@ func (s *AccessService) CheckAccess(ctx context.Context, p *accesssvc.CheckAcces
 		return &accesssvc.CheckAccessResult{Results: []string{}}, nil
 	}
 
-	// === BUSINESS LOGIC (embedded in service) ===
-	results, err := s.performAccessCheck(ctx, claims.Principal, p.Requests)
+	results, err := s.client.CheckAccess(ctx, claims.Principal, p.Requests)
 	if err != nil {
 		slog.ErrorContext(ctx, "Access check failed", "error", err, "principal", claims.Principal)
 		switch {
@@ -104,32 +112,28 @@ func (s *AccessService) CheckAccess(ctx context.Context, p *accesssvc.CheckAcces
 	}
 
 	slog.InfoContext(ctx, "Access check completed", "principal", claims.Principal, "requests_count", len(p.Requests))
-
 	return &accesssvc.CheckAccessResult{Results: results}, nil
 }
 
-// MyGrants implements the my-grants endpoint, returning the caller's direct OpenFGA tuples.
+// MyGrants validates the request and delegates to AccessCheckClient.
 func (s *AccessService) MyGrants(ctx context.Context, p *accesssvc.MyGrantsPayload) (*accesssvc.MyGrantsResult, error) {
-	// Extract claims from context.
-	claims, ok := ctx.Value(constants.ClaimsContextKey).(*contracts.HeimdallClaims)
+	claims, ok := claimsFromContext(ctx)
 	if !ok {
 		slog.ErrorContext(ctx, "Failed to get claims from context")
 		return nil, accesssvc.MakeUnauthorized(constants.ErrInvalidAuthContext)
 	}
 
-	// Validate API version.
-	if p.Version != constants.SupportedAPIVersion {
+	if err := requireAPIVersion(p.Version); err != nil {
 		slog.WarnContext(ctx, "Unsupported API version", "version", p.Version)
-		return nil, accesssvc.MakeBadRequest(fmt.Errorf("%s: %s", constants.ErrMsgUnsupportedAPIVersion, p.Version))
+		return nil, accesssvc.MakeBadRequest(err)
 	}
 
-	// Validate principal.
 	if claims.Principal == "" {
 		slog.ErrorContext(ctx, "Principal is required for my-grants")
 		return nil, accesssvc.MakeUnauthorized(constants.ErrPrincipalRequired)
 	}
 
-	grants, err := s.performReadTuples(ctx, claims.Principal, p.ObjectType)
+	grants, err := s.client.ReadTuples(ctx, claims.Principal, p.ObjectType)
 	if err != nil {
 		slog.ErrorContext(ctx, "Reading tuples failed", "error", err, "principal", claims.Principal, "subject", constants.ReadTuplesSubject, "object_type", p.ObjectType)
 		if errors.Is(err, constants.ErrUnexpectedResponse) {
@@ -142,32 +146,18 @@ func (s *AccessService) MyGrants(ctx context.Context, p *accesssvc.MyGrantsPaylo
 	return &accesssvc.MyGrantsResult{Grants: grants}, nil
 }
 
-// readTuplesRequest is the JSON payload sent to fga-sync over NATS.
-type readTuplesRequest struct {
-	User       string `json:"user"`
-	ObjectType string `json:"object_type"`
-}
-
-// readTuplesResponse is the JSON response received from fga-sync over NATS.
-type readTuplesResponse struct {
-	Results []string `json:"results,omitempty"`
-	Error   string   `json:"error,omitempty"`
-}
-
-// Readyz implements the readiness check endpoint with comprehensive health checks
+// Readyz checks that both messaging and auth dependencies are healthy.
 func (s *AccessService) Readyz(ctx context.Context) ([]byte, error) {
 	var healthIssues []string
 
-	// Check if messaging repository is available and healthy
-	if s.messagingRepo == nil {
-		healthIssues = append(healthIssues, constants.ErrMsgMessagingRepoNotInit)
-	} else {
-		if err := s.messagingRepo.HealthCheck(ctx); err != nil {
+	if err := s.client.HealthCheck(ctx); err != nil {
+		if errors.Is(err, constants.ErrMessagingRepoNotInit) {
+			healthIssues = append(healthIssues, constants.ErrMsgMessagingRepoNotInit)
+		} else {
 			healthIssues = append(healthIssues, fmt.Sprintf("%s: %v", constants.ErrMsgNATSConnUnhealthy, err))
 		}
 	}
 
-	// Check if auth repository is available and healthy
 	if s.authRepo == nil {
 		healthIssues = append(healthIssues, constants.ErrMsgAuthRepoNotInit)
 	} else {
@@ -176,7 +166,6 @@ func (s *AccessService) Readyz(ctx context.Context) ([]byte, error) {
 		}
 	}
 
-	// If any health checks failed, return not ready
 	if len(healthIssues) > 0 {
 		slog.ErrorContext(ctx, "Readiness check failed", "issues", healthIssues)
 		return nil, accesssvc.MakeNotReady(fmt.Errorf("%s: %v", constants.ErrMsgServiceDepsUnhealthy, healthIssues))
@@ -186,131 +175,8 @@ func (s *AccessService) Readyz(ctx context.Context) ([]byte, error) {
 	return []byte(constants.HealthOKResponse), nil
 }
 
-// Livez implements the liveness check endpoint
+// Livez always succeeds; as long as the process is running the service is live.
 func (s *AccessService) Livez(ctx context.Context) ([]byte, error) {
-	// Liveness check - as long as the service is running, it's alive
 	slog.DebugContext(ctx, "Liveness check requested")
 	return []byte(constants.HealthOKResponse), nil
-}
-
-// ===== PRIVATE BUSINESS LOGIC METHODS =====
-
-// performAccessCheck contains the core business logic for access checking
-func (s *AccessService) performAccessCheck(ctx context.Context, principal string, resources []string) ([]string, error) {
-	if principal == "" {
-		return nil, constants.ErrPrincipalRequired
-	}
-
-	if len(resources) == 0 {
-		return []string{}, nil
-	}
-
-	// Build access check message
-	message := s.buildAccessCheckMessage(principal, resources)
-	if message == "" {
-		return []string{}, nil
-	}
-
-	// Make NATS request
-	responseData, err := s.messagingRepo.Request(ctx, constants.AccessCheckSubject, []byte(message), constants.DefaultNATSTimeout)
-	if err != nil {
-		return nil, fmt.Errorf("NATS request to subject %s failed: %w", constants.AccessCheckSubject, err)
-	}
-
-	// Parse and validate response
-	return s.parseAccessCheckResponse(ctx, responseData)
-}
-
-// performReadTuples fetches the direct OpenFGA tuples for a principal via NATS.
-func (s *AccessService) performReadTuples(ctx context.Context, principal string, objectType string) ([]string, error) {
-	reqPayload, err := json.Marshal(readTuplesRequest{
-		User:       constants.UserTypePrefix + principal,
-		ObjectType: objectType,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("%w: failed to build read tuples request: %v", constants.ErrUnexpectedResponse, err)
-	}
-
-	responseData, err := s.messagingRepo.Request(ctx, constants.ReadTuplesSubject, reqPayload, constants.DefaultNATSTimeout)
-	if err != nil {
-		return nil, fmt.Errorf("NATS request to subject %s failed: %w", constants.ReadTuplesSubject, err)
-	}
-
-	var resp readTuplesResponse
-	if err := json.Unmarshal(responseData, &resp); err != nil {
-		return nil, fmt.Errorf("%w: failed to parse read tuples response: %v", constants.ErrUnexpectedResponse, err)
-	}
-
-	if resp.Error != "" {
-		return nil, fmt.Errorf("message to subject %s failed with FGA error: %s", constants.ReadTuplesSubject, resp.Error)
-	}
-
-	if resp.Results == nil {
-		return []string{}, nil
-	}
-	return resp.Results, nil
-}
-
-// buildAccessCheckMessage creates the NATS message for access checking using efficient string building
-// add newlines after each item, then remove trailing one
-func (s *AccessService) buildAccessCheckMessage(principal string, resources []string) string {
-	var builder strings.Builder
-
-	// Calculate actual capacity based on real data instead of estimates
-	totalCapacity := 0
-	for _, resource := range resources {
-		if resource != "" {
-			// resource + "@user:" + principal + newline
-			totalCapacity += len(resource) + len(constants.UserRelationPrefix) + len(principal) + 1
-		}
-	}
-
-	if totalCapacity > 0 {
-		builder.Grow(totalCapacity)
-	}
-
-	for _, resource := range resources {
-		if resource == "" {
-			continue
-		}
-
-		// Build relation: resource@user:principal
-		builder.WriteString(resource)
-		builder.WriteString(constants.UserRelationPrefix)
-		builder.WriteString(principal)
-		builder.WriteByte('\n')
-	}
-
-	message := builder.String()
-
-	// Remove trailing newline if present
-	if len(message) > 0 && message[len(message)-1] == '\n' {
-		message = message[:len(message)-1]
-	}
-
-	return message
-} // parseAccessCheckResponse parses and validates the NATS response
-func (s *AccessService) parseAccessCheckResponse(ctx context.Context, responseData []byte) ([]string, error) {
-	// Sanity check response - if there's a space in the first N bytes, assume it's an error
-	topRange := constants.DefaultResponseSanityCheckBytes
-	if len(responseData) < topRange {
-		topRange = len(responseData)
-	}
-	if bytes.Contains(responseData[:topRange], []byte(" ")) {
-		return nil, fmt.Errorf("%w: response_preview=%q", constants.ErrUnexpectedResponse, string(responseData[:topRange]))
-	}
-
-	// Parse response - split by newlines to get individual results
-	lines := bytes.Split(responseData, []byte("\n"))
-	results := make([]string, 0, len(lines))
-
-	for _, line := range lines {
-		line = bytes.TrimSpace(line)
-		if len(line) == 0 {
-			continue
-		}
-		results = append(results, string(line))
-	}
-
-	return results, nil
 }

--- a/internal/service/access_service_bench_test.go
+++ b/internal/service/access_service_bench_test.go
@@ -9,12 +9,9 @@ import (
 	"time"
 )
 
-// Simple benchmark for the refactored buildAccessCheckMessage method
-func BenchmarkBuildAccessCheckMessage(b *testing.B) {
-	authRepo := &mockAuthRepository{}
-	messagingRepo := &mockMessagingRepository{}
-	service := NewAccessService(authRepo, messagingRepo)
-
+// BenchmarkBuildMessage measures the NATS message construction path.
+func BenchmarkBuildMessage(b *testing.B) {
+	client := NewAccessCheckClient(&mockMessagingRepository{})
 	principal := "test-user-with-long-name"
 	resources := []string{
 		"repository/project1",
@@ -31,35 +28,28 @@ func BenchmarkBuildAccessCheckMessage(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = service.buildAccessCheckMessage(principal, resources)
+		_ = client.buildMessage(principal, resources)
 	}
 }
 
-// Benchmark for the parseAccessCheckResponse method
-func BenchmarkParseAccessCheckResponse(b *testing.B) {
-	authRepo := &mockAuthRepository{}
-	messagingRepo := &mockMessagingRepository{}
-	service := NewAccessService(authRepo, messagingRepo)
-
-	ctx := context.Background()
+// BenchmarkParseResponse measures the NATS response parsing path.
+func BenchmarkParseResponse(b *testing.B) {
+	client := NewAccessCheckClient(&mockMessagingRepository{})
 	responseData := []byte("true\nfalse\ntrue\nfalse\ntrue\nfalse\ntrue\nfalse\ntrue\nfalse")
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = service.parseAccessCheckResponse(ctx, responseData)
+		_, _ = client.parseResponse(responseData)
 	}
 }
 
-// End-to-end benchmark for the entire performAccessCheck flow (mocked NATS)
-func BenchmarkPerformAccessCheck(b *testing.B) {
-	authRepo := &mockAuthRepository{}
-	messagingRepo := &mockMessagingRepository{
+// BenchmarkCheckAccess measures the full CheckAccess path with a mocked NATS response.
+func BenchmarkCheckAccess(b *testing.B) {
+	client := NewAccessCheckClient(&mockMessagingRepository{
 		requestFunc: func(_ context.Context, _ string, _ []byte, _ time.Duration) ([]byte, error) {
 			return []byte("true\nfalse\ntrue\nfalse\ntrue"), nil
 		},
-	}
-	service := NewAccessService(authRepo, messagingRepo)
-
+	})
 	ctx := context.Background()
 	principal := "test-user-with-long-name"
 	resources := []string{
@@ -72,6 +62,6 @@ func BenchmarkPerformAccessCheck(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = service.performAccessCheck(ctx, principal, resources)
+		_, _ = client.CheckAccess(ctx, principal, resources)
 	}
 }

--- a/internal/service/access_service_test.go
+++ b/internal/service/access_service_test.go
@@ -5,6 +5,7 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -12,6 +13,7 @@ import (
 	accesssvc "github.com/linuxfoundation/lfx-v2-access-check/gen/access_svc"
 	"github.com/linuxfoundation/lfx-v2-access-check/internal/domain/contracts"
 	"github.com/linuxfoundation/lfx-v2-access-check/pkg/constants"
+	goa "goa.design/goa/v3/pkg"
 	"goa.design/goa/v3/security"
 )
 
@@ -331,3 +333,105 @@ func TestMyGrants_MissingClaims(t *testing.T) {
 		t.Fatal("expected unauthorized error, got nil")
 	}
 }
+
+// ===== Goa error-mapping tests =====
+// These tests assert the *goa.ServiceError.Name field so that regressions in
+// the InternalServerError / ServiceUnavailable mapping cannot pass silently.
+
+func goaErrorName(t *testing.T, err error) string {
+	t.Helper()
+	var svcErr *goa.ServiceError
+	if !errors.As(err, &svcErr) {
+		t.Fatalf("expected *goa.ServiceError, got %T: %v", err, err)
+	}
+	return svcErr.Name
+}
+
+func TestCheckAccess_ErrorMapping(t *testing.T) {
+	natsErr := errors.New("NATS connection failed")
+
+	tests := []struct {
+		name         string
+		clientErr    error
+		wantGoaName  string
+	}{
+		{
+			name:        "ErrUnexpectedResponse → 500 InternalServerError",
+			clientErr:   fmt.Errorf("wrap: %w", constants.ErrUnexpectedResponse),
+			wantGoaName: "InternalServerError",
+		},
+		{
+			name:        "NATS transport error → 503 ServiceUnavailable",
+			clientErr:   natsErr,
+			wantGoaName: "ServiceUnavailable",
+		},
+		{
+			name:        "ErrPrincipalRequired → 401 Unauthorized",
+			clientErr:   constants.ErrPrincipalRequired,
+			wantGoaName: "Unauthorized",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := NewAccessService(&mockAuthRepository{}, &mockMessagingRepository{
+				requestFunc: func(_ context.Context, _ string, _ []byte, _ time.Duration) ([]byte, error) {
+					return nil, tc.clientErr
+				},
+			})
+			_, err := svc.CheckAccess(contextWithClaims("alice"), &accesssvc.CheckAccessPayload{
+				Version:  "1",
+				Requests: []string{"project:abc#viewer"},
+			})
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if got := goaErrorName(t, err); got != tc.wantGoaName {
+				t.Errorf("expected Goa error name %q, got %q", tc.wantGoaName, got)
+			}
+		})
+	}
+}
+
+func TestMyGrants_ErrorMapping(t *testing.T) {
+	natsErr := errors.New("NATS connection failed")
+
+	tests := []struct {
+		name        string
+		clientErr   error
+		wantGoaName string
+	}{
+		{
+			name:        "ErrUnexpectedResponse → 500 InternalServerError",
+			clientErr:   fmt.Errorf("wrap: %w", constants.ErrUnexpectedResponse),
+			wantGoaName: "InternalServerError",
+		},
+		{
+			name:        "NATS transport error → 503 ServiceUnavailable",
+			clientErr:   natsErr,
+			wantGoaName: "ServiceUnavailable",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := NewAccessService(&mockAuthRepository{}, &mockMessagingRepository{
+				requestFunc: func(_ context.Context, _ string, _ []byte, _ time.Duration) ([]byte, error) {
+					return nil, tc.clientErr
+				},
+			})
+			_, err := svc.MyGrants(contextWithClaims("alice"), &accesssvc.MyGrantsPayload{
+				BearerToken: "tok",
+				Version:     "1",
+				ObjectType:  "project",
+			})
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if got := goaErrorName(t, err); got != tc.wantGoaName {
+				t.Errorf("expected Goa error name %q, got %q", tc.wantGoaName, got)
+			}
+		})
+	}
+}
+

--- a/internal/service/access_service_test.go
+++ b/internal/service/access_service_test.go
@@ -15,7 +15,8 @@ import (
 	"goa.design/goa/v3/security"
 )
 
-// Mock implementations for testing
+// Mock implementations for testing — shared by service and client tests in this package.
+
 type mockAuthRepository struct {
 	validateTokenFunc func(ctx context.Context, token string) (*contracts.HeimdallClaims, error)
 }
@@ -54,18 +55,19 @@ func (m *mockMessagingRepository) HealthCheck(_ context.Context) error {
 	return nil
 }
 
+// contextWithClaims returns a context with HeimdallClaims pre-loaded.
+func contextWithClaims(principal string) context.Context {
+	claims := &contracts.HeimdallClaims{Principal: principal, Email: "test@example.com"}
+	return context.WithValue(context.Background(), constants.ClaimsContextKey, claims)
+}
+
+// ===== AccessService unit tests =====
+
 func TestNewAccessService(t *testing.T) {
-	authRepo := &mockAuthRepository{}
-	messagingRepo := &mockMessagingRepository{}
-
-	service := NewAccessService(authRepo, messagingRepo)
-
+	service := NewAccessService(&mockAuthRepository{}, &mockMessagingRepository{})
 	if service == nil {
 		t.Fatal("NewAccessService returned nil")
 	}
-
-	// Service is properly initialized if it's not nil
-	// Internal field validation is not necessary for public API tests
 }
 
 func TestJWTAuth_Success(t *testing.T) {
@@ -74,26 +76,19 @@ func TestJWTAuth_Success(t *testing.T) {
 			return &contracts.HeimdallClaims{Principal: "test-user", Email: "test@example.com"}, nil
 		},
 	}
-	messagingRepo := &mockMessagingRepository{}
-	service := NewAccessService(authRepo, messagingRepo)
+	service := NewAccessService(authRepo, &mockMessagingRepository{})
 
-	ctx := context.Background()
-	scheme := &security.JWTScheme{}
-
-	// Test with Bearer prefix
-	resultCtx, err := service.JWTAuth(ctx, "Bearer valid-token", scheme)
+	resultCtx, err := service.JWTAuth(context.Background(), "Bearer valid-token", &security.JWTScheme{})
 	if err != nil {
 		t.Fatalf("JWTAuth failed: %v", err)
 	}
 
-	// Check that claims are in context
 	claims, ok := resultCtx.Value(constants.ClaimsContextKey).(*contracts.HeimdallClaims)
 	if !ok {
 		t.Fatal("Claims not found in context")
 	}
-
 	if claims.Principal != "test-user" {
-		t.Errorf("Expected principal 'test-user', got '%s'", claims.Principal)
+		t.Errorf("expected principal 'test-user', got '%s'", claims.Principal)
 	}
 }
 
@@ -101,19 +96,14 @@ func TestJWTAuth_WithoutBearerPrefix(t *testing.T) {
 	authRepo := &mockAuthRepository{
 		validateTokenFunc: func(_ context.Context, token string) (*contracts.HeimdallClaims, error) {
 			if token != "valid-token" {
-				t.Errorf("Expected token 'valid-token', got '%s'", token)
+				t.Errorf("expected token 'valid-token', got '%s'", token)
 			}
 			return &contracts.HeimdallClaims{Principal: "test-user"}, nil
 		},
 	}
-	messagingRepo := &mockMessagingRepository{}
-	service := NewAccessService(authRepo, messagingRepo)
+	service := NewAccessService(authRepo, &mockMessagingRepository{})
 
-	ctx := context.Background()
-	scheme := &security.JWTScheme{}
-
-	// Test without Bearer prefix
-	_, err := service.JWTAuth(ctx, "valid-token", scheme)
+	_, err := service.JWTAuth(context.Background(), "valid-token", &security.JWTScheme{})
 	if err != nil {
 		t.Fatalf("JWTAuth failed: %v", err)
 	}
@@ -125,53 +115,38 @@ func TestJWTAuth_InvalidToken(t *testing.T) {
 			return nil, errors.New("invalid token")
 		},
 	}
-	messagingRepo := &mockMessagingRepository{}
-	service := NewAccessService(authRepo, messagingRepo)
+	service := NewAccessService(authRepo, &mockMessagingRepository{})
 
-	ctx := context.Background()
-	scheme := &security.JWTScheme{}
-
-	_, err := service.JWTAuth(ctx, "invalid-token", scheme)
+	_, err := service.JWTAuth(context.Background(), "invalid-token", &security.JWTScheme{})
 	if err == nil {
 		t.Fatal("JWTAuth should have failed with invalid token")
 	}
-
-	// Just verify it's an error - the exact type checking is less important for unit tests
 	t.Logf("Got expected error: %v", err)
 }
 
 func TestCheckAccess_Success(t *testing.T) {
-	authRepo := &mockAuthRepository{}
 	messagingRepo := &mockMessagingRepository{
 		requestFunc: func(_ context.Context, subject string, _ []byte, _ time.Duration) ([]byte, error) {
-			if subject != "lfx.access_check.request" {
-				t.Errorf("Expected subject 'lfx.access_check.request', got '%s'", subject)
+			if subject != constants.AccessCheckSubject {
+				t.Errorf("expected subject %q, got %q", constants.AccessCheckSubject, subject)
 			}
 			return []byte("project:a27394a3-7a6c-4d0f-9e0f-692d8753924f#auditor@user:auth0|alice\ttrue"), nil
 		},
 	}
-	service := NewAccessService(authRepo, messagingRepo)
+	service := NewAccessService(&mockAuthRepository{}, messagingRepo)
 
-	// Create context with claims
-	claims := &contracts.HeimdallClaims{Principal: "test-user", Email: "test@example.com"}
-	ctx := context.WithValue(context.Background(), constants.ClaimsContextKey, claims)
+	ctx := context.WithValue(context.Background(), constants.ClaimsContextKey,
+		&contracts.HeimdallClaims{Principal: "test-user", Email: "test@example.com"})
 
-	payload := &accesssvc.CheckAccessPayload{
+	result, err := service.CheckAccess(ctx, &accesssvc.CheckAccessPayload{
 		Version:  "1",
 		Requests: []string{"resource1", "resource2"},
-	}
-
-	result, err := service.CheckAccess(ctx, payload)
+	})
 	if err != nil {
 		t.Fatalf("CheckAccess failed: %v", err)
 	}
-
-	if result == nil {
-		t.Fatal("CheckAccess returned nil result")
-	}
-
 	if len(result.Results) != 1 {
-		t.Errorf("Expected 1 result, got %d", len(result.Results))
+		t.Errorf("expected 1 result, got %d", len(result.Results))
 	}
 
 	expectedPrefix := "project:a27394a3-7a6c-4d0f-9e0f-692d8753924f#auditor@user:auth0|alice"
@@ -183,215 +158,103 @@ func TestCheckAccess_Success(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Errorf("Expected result with prefix %q and suffix \\ttrue, got %v", expectedPrefix, result.Results)
+		t.Errorf("expected result with prefix %q and suffix \\ttrue, got %v", expectedPrefix, result.Results)
 	}
 }
 
 func TestCheckAccess_MissingClaims(t *testing.T) {
-	authRepo := &mockAuthRepository{}
-	messagingRepo := &mockMessagingRepository{}
-	service := NewAccessService(authRepo, messagingRepo)
+	service := NewAccessService(&mockAuthRepository{}, &mockMessagingRepository{})
 
-	// Context without claims
-	ctx := context.Background()
-
-	payload := &accesssvc.CheckAccessPayload{
+	_, err := service.CheckAccess(context.Background(), &accesssvc.CheckAccessPayload{
 		Version:  "1",
 		Requests: []string{"resource1"},
-	}
-
-	_, err := service.CheckAccess(ctx, payload)
+	})
 	if err == nil {
-		t.Fatal("CheckAccess should have failed without claims")
+		t.Fatal("CheckAccess should fail without claims in context")
 	}
-
 	t.Logf("Got expected error: %v", err)
 }
 
 func TestCheckAccess_UnsupportedVersion(t *testing.T) {
-	authRepo := &mockAuthRepository{}
-	messagingRepo := &mockMessagingRepository{}
-	service := NewAccessService(authRepo, messagingRepo)
+	service := NewAccessService(&mockAuthRepository{}, &mockMessagingRepository{})
+	ctx := contextWithClaims("test-user")
 
-	// Create context with claims
-	claims := &contracts.HeimdallClaims{Principal: "test-user"}
-	ctx := context.WithValue(context.Background(), constants.ClaimsContextKey, claims)
-
-	payload := &accesssvc.CheckAccessPayload{
-		Version:  "2", // Unsupported version
+	_, err := service.CheckAccess(ctx, &accesssvc.CheckAccessPayload{
+		Version:  "2",
 		Requests: []string{"resource1"},
-	}
-
-	_, err := service.CheckAccess(ctx, payload)
+	})
 	if err == nil {
-		t.Fatal("CheckAccess should have failed with unsupported version")
+		t.Fatal("CheckAccess should fail with unsupported version")
 	}
-
 	t.Logf("Got expected error: %v", err)
 }
 
 func TestCheckAccess_EmptyRequests(t *testing.T) {
-	authRepo := &mockAuthRepository{}
-	messagingRepo := &mockMessagingRepository{}
-	service := NewAccessService(authRepo, messagingRepo)
+	service := NewAccessService(&mockAuthRepository{}, &mockMessagingRepository{})
+	ctx := contextWithClaims("test-user")
 
-	// Create context with claims
-	claims := &contracts.HeimdallClaims{Principal: "test-user"}
-	ctx := context.WithValue(context.Background(), constants.ClaimsContextKey, claims)
-
-	payload := &accesssvc.CheckAccessPayload{
+	result, err := service.CheckAccess(ctx, &accesssvc.CheckAccessPayload{
 		Version:  "1",
-		Requests: []string{}, // Empty requests
-	}
-
-	result, err := service.CheckAccess(ctx, payload)
+		Requests: []string{},
+	})
 	if err != nil {
 		t.Fatalf("CheckAccess failed: %v", err)
 	}
-
-	if result == nil {
-		t.Fatal("CheckAccess returned nil result")
-	}
-
 	if len(result.Results) != 0 {
-		t.Errorf("Expected 0 results for empty requests, got %d", len(result.Results))
+		t.Errorf("expected 0 results for empty requests, got %d", len(result.Results))
 	}
 }
 
 func TestCheckAccess_NATSFailure(t *testing.T) {
-	authRepo := &mockAuthRepository{}
 	messagingRepo := &mockMessagingRepository{
 		requestFunc: func(_ context.Context, _ string, _ []byte, _ time.Duration) ([]byte, error) {
 			return nil, errors.New("NATS connection failed")
 		},
 	}
-	service := NewAccessService(authRepo, messagingRepo)
+	service := NewAccessService(&mockAuthRepository{}, messagingRepo)
 
-	// Create context with claims
-	claims := &contracts.HeimdallClaims{Principal: "test-user"}
-	ctx := context.WithValue(context.Background(), constants.ClaimsContextKey, claims)
-
-	payload := &accesssvc.CheckAccessPayload{
+	_, err := service.CheckAccess(contextWithClaims("test-user"), &accesssvc.CheckAccessPayload{
 		Version:  "1",
 		Requests: []string{"resource1"},
-	}
-
-	_, err := service.CheckAccess(ctx, payload)
+	})
 	if err == nil {
-		t.Fatal("CheckAccess should have failed with NATS error")
+		t.Fatal("CheckAccess should fail on NATS error")
 	}
-
 	t.Logf("Got expected error: %v", err)
 }
 
 func TestReadyz_Success(t *testing.T) {
-	authRepo := &mockAuthRepository{}
-	messagingRepo := &mockMessagingRepository{}
-	service := NewAccessService(authRepo, messagingRepo)
+	service := NewAccessService(&mockAuthRepository{}, &mockMessagingRepository{})
 
-	ctx := context.Background()
-
-	result, err := service.Readyz(ctx)
+	result, err := service.Readyz(context.Background())
 	if err != nil {
 		t.Fatalf("Readyz failed: %v", err)
 	}
-
 	if string(result) != "OK" {
-		t.Errorf("Expected 'OK', got '%s'", string(result))
+		t.Errorf("expected 'OK', got '%s'", string(result))
 	}
 }
 
 func TestReadyz_MessagingRepoNil(t *testing.T) {
-	authRepo := &mockAuthRepository{}
-	service := NewAccessService(authRepo, nil) // nil messaging repo
+	service := NewAccessService(&mockAuthRepository{}, nil)
 
-	ctx := context.Background()
-
-	_, err := service.Readyz(ctx)
+	_, err := service.Readyz(context.Background())
 	if err == nil {
-		t.Fatal("Readyz should have failed with nil messaging repo")
+		t.Fatal("Readyz should fail with nil messaging repo")
 	}
-
 	t.Logf("Got expected error: %v", err)
 }
 
 func TestLivez(t *testing.T) {
-	authRepo := &mockAuthRepository{}
-	messagingRepo := &mockMessagingRepository{}
-	service := NewAccessService(authRepo, messagingRepo)
+	service := NewAccessService(&mockAuthRepository{}, &mockMessagingRepository{})
 
-	ctx := context.Background()
-
-	result, err := service.Livez(ctx)
+	result, err := service.Livez(context.Background())
 	if err != nil {
 		t.Fatalf("Livez failed: %v", err)
 	}
-
 	if string(result) != "OK" {
-		t.Errorf("Expected 'OK', got '%s'", string(result))
+		t.Errorf("expected 'OK', got '%s'", string(result))
 	}
-}
-
-func TestPerformAccessCheck_EmptyPrincipal(t *testing.T) {
-	authRepo := &mockAuthRepository{}
-	messagingRepo := &mockMessagingRepository{}
-	service := NewAccessService(authRepo, messagingRepo)
-
-	ctx := context.Background()
-
-	_, err := service.performAccessCheck(ctx, "", []string{"resource1"})
-	if err == nil {
-		t.Fatal("performAccessCheck should have failed with empty principal")
-	}
-
-	if err.Error() != "principal is required" {
-		t.Errorf("Expected 'principal is required', got '%s'", err.Error())
-	}
-}
-
-func TestPerformAccessCheck_EmptyResources(t *testing.T) {
-	authRepo := &mockAuthRepository{}
-	messagingRepo := &mockMessagingRepository{}
-	service := NewAccessService(authRepo, messagingRepo)
-
-	ctx := context.Background()
-
-	result, err := service.performAccessCheck(ctx, "test-user", []string{})
-	if err != nil {
-		t.Fatalf("performAccessCheck failed: %v", err)
-	}
-
-	if len(result) != 0 {
-		t.Errorf("Expected empty result for empty resources, got %d items", len(result))
-	}
-}
-
-func TestPerformAccessCheck_UnexpectedResponse(t *testing.T) {
-	authRepo := &mockAuthRepository{}
-	messagingRepo := &mockMessagingRepository{
-		requestFunc: func(_ context.Context, _ string, _ []byte, _ time.Duration) ([]byte, error) {
-			// Return response with space in first 20 bytes (indicates error)
-			return []byte("error message here"), nil
-		},
-	}
-	service := NewAccessService(authRepo, messagingRepo)
-
-	ctx := context.Background()
-
-	_, err := service.performAccessCheck(ctx, "test-user", []string{"resource1"})
-	if err == nil {
-		t.Fatal("performAccessCheck should have failed with unexpected response")
-	}
-
-	if !errors.Is(err, constants.ErrUnexpectedResponse) {
-		t.Errorf("Expected ErrUnexpectedResponse, got '%s'", err.Error())
-	}
-}
-
-// contextWithClaims returns a context with HeimdallClaims pre-loaded.
-func contextWithClaims(principal string) context.Context {
-	claims := &contracts.HeimdallClaims{Principal: principal, Email: "test@example.com"}
-	return context.WithValue(context.Background(), constants.ClaimsContextKey, claims)
 }
 
 func TestMyGrants_Success(t *testing.T) {
@@ -411,7 +274,6 @@ func TestMyGrants_Success(t *testing.T) {
 		Version:     "1",
 		ObjectType:  "project",
 	})
-
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -433,7 +295,6 @@ func TestMyGrants_EmptyResults(t *testing.T) {
 		Version:     "1",
 		ObjectType:  "committee",
 	})
-
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -453,7 +314,6 @@ func TestMyGrants_UnsupportedVersion(t *testing.T) {
 		Version:     "2",
 		ObjectType:  "project",
 	})
-
 	if err == nil {
 		t.Fatal("expected error for unsupported version, got nil")
 	}
@@ -467,225 +327,7 @@ func TestMyGrants_MissingClaims(t *testing.T) {
 		Version:     "1",
 		ObjectType:  "project",
 	})
-
 	if err == nil {
 		t.Fatal("expected unauthorized error, got nil")
-	}
-}
-
-func TestPerformReadTuples_Success(t *testing.T) {
-	messagingRepo := &mockMessagingRepository{
-		requestFunc: func(_ context.Context, subject string, _ []byte, _ time.Duration) ([]byte, error) {
-			if subject != constants.ReadTuplesSubject {
-				t.Errorf("unexpected NATS subject: %s", subject)
-			}
-			return []byte(`{"results":["project:abc#auditor@user:alice","committee:xyz#writer@user:alice"]}`), nil
-		},
-	}
-	svc := NewAccessService(&mockAuthRepository{}, messagingRepo)
-
-	results, err := svc.performReadTuples(context.Background(), "alice", "project")
-	if err != nil {
-		t.Fatalf("performReadTuples failed: %v", err)
-	}
-	if len(results) != 2 {
-		t.Errorf("expected 2 results, got %d", len(results))
-	}
-}
-
-func TestPerformReadTuples_NilResultsNormalized(t *testing.T) {
-	messagingRepo := &mockMessagingRepository{
-		requestFunc: func(_ context.Context, _ string, _ []byte, _ time.Duration) ([]byte, error) {
-			return []byte(`{}`), nil
-		},
-	}
-	svc := NewAccessService(&mockAuthRepository{}, messagingRepo)
-
-	results, err := svc.performReadTuples(context.Background(), "alice", "project")
-	if err != nil {
-		t.Fatalf("performReadTuples failed: %v", err)
-	}
-	if results == nil {
-		t.Error("expected empty slice, got nil")
-	}
-	if len(results) != 0 {
-		t.Errorf("expected 0 results, got %d", len(results))
-	}
-}
-
-func TestPerformReadTuples_NATSFailure(t *testing.T) {
-	messagingRepo := &mockMessagingRepository{
-		requestFunc: func(_ context.Context, _ string, _ []byte, _ time.Duration) ([]byte, error) {
-			return nil, errors.New("nats timeout")
-		},
-	}
-	svc := NewAccessService(&mockAuthRepository{}, messagingRepo)
-
-	_, err := svc.performReadTuples(context.Background(), "alice", "project")
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), "NATS request to subject") {
-		t.Errorf("expected NATS transport error message, got '%s'", err.Error())
-	}
-}
-
-func TestPerformReadTuples_UnmarshalFailure(t *testing.T) {
-	messagingRepo := &mockMessagingRepository{
-		requestFunc: func(_ context.Context, _ string, _ []byte, _ time.Duration) ([]byte, error) {
-			return []byte(`not valid json`), nil
-		},
-	}
-	svc := NewAccessService(&mockAuthRepository{}, messagingRepo)
-
-	_, err := svc.performReadTuples(context.Background(), "alice", "project")
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !errors.Is(err, constants.ErrUnexpectedResponse) {
-		t.Errorf("expected ErrUnexpectedResponse, got '%s'", err.Error())
-	}
-}
-
-func TestPerformReadTuples_BackendError(t *testing.T) {
-	messagingRepo := &mockMessagingRepository{
-		requestFunc: func(_ context.Context, _ string, _ []byte, _ time.Duration) ([]byte, error) {
-			return []byte(`{"error":"store not found"}`), nil
-		},
-	}
-	svc := NewAccessService(&mockAuthRepository{}, messagingRepo)
-
-	_, err := svc.performReadTuples(context.Background(), "alice", "project")
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), "FGA error") {
-		t.Errorf("expected FGA error message, got '%s'", err.Error())
-	}
-	if strings.Contains(err.Error(), "NATS request") {
-		t.Errorf("backend error should not look like a NATS transport error, got '%s'", err.Error())
-	}
-}
-
-// Unit tests for refactored helper methods
-
-func TestBuildAccessCheckMessage(t *testing.T) {
-	authRepo := &mockAuthRepository{}
-	messagingRepo := &mockMessagingRepository{}
-	service := NewAccessService(authRepo, messagingRepo)
-
-	tests := []struct {
-		name      string
-		principal string
-		resources []string
-		expected  string
-	}{
-		{
-			name:      "empty resources",
-			principal: "user1",
-			resources: []string{},
-			expected:  "",
-		},
-		{
-			name:      "single resource",
-			principal: "user1",
-			resources: []string{"repo1"},
-			expected:  "repo1@user:user1",
-		},
-		{
-			name:      "multiple resources",
-			principal: "user1",
-			resources: []string{"repo1", "repo2"},
-			expected:  "repo1@user:user1\nrepo2@user:user1",
-		},
-		{
-			name:      "empty resource filtered out",
-			principal: "user1",
-			resources: []string{"repo1", "", "repo2"},
-			expected:  "repo1@user:user1\nrepo2@user:user1",
-		},
-		{
-			name:      "all empty resources",
-			principal: "user1",
-			resources: []string{"", "", ""},
-			expected:  "",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			result := service.buildAccessCheckMessage(test.principal, test.resources)
-			if result != test.expected {
-				t.Errorf("Expected '%s', got '%s'", test.expected, result)
-			}
-		})
-	}
-}
-
-func TestParseAccessCheckResponse(t *testing.T) {
-	authRepo := &mockAuthRepository{}
-	messagingRepo := &mockMessagingRepository{}
-	service := NewAccessService(authRepo, messagingRepo)
-
-	ctx := context.Background()
-
-	tests := []struct {
-		name         string
-		responseData []byte
-		expected     []string
-		expectError  bool
-	}{
-		{
-			name:         "valid response",
-			responseData: []byte("true\nfalse\ntrue"),
-			expected:     []string{"true", "false", "true"},
-			expectError:  false,
-		},
-		{
-			name:         "empty response",
-			responseData: []byte(""),
-			expected:     []string{},
-			expectError:  false,
-		},
-		{
-			name:         "response with empty lines",
-			responseData: []byte("true\n\nfalse\n"),
-			expected:     []string{"true", "false"},
-			expectError:  false,
-		},
-		{
-			name:         "response with spaces (error)",
-			responseData: []byte("error message here"),
-			expected:     nil,
-			expectError:  true,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			result, err := service.parseAccessCheckResponse(ctx, test.responseData)
-
-			if test.expectError {
-				if err == nil {
-					t.Fatal("Expected error but got none")
-				}
-				return
-			}
-
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-
-			if len(result) != len(test.expected) {
-				t.Errorf("Expected %d results, got %d", len(test.expected), len(result))
-				return
-			}
-
-			for i, expected := range test.expected {
-				if result[i] != expected {
-					t.Errorf("Expected result[%d] = '%s', got '%s'", i, expected, result[i])
-				}
-			}
-		})
 	}
 }


### PR DESCRIPTION
## Summary

Resolves [LFXV2-2983](https://linuxfoundation.atlassian.net/browse/LFXV2-2983).

`AccessService` previously owned four distinct concerns in a single ~316-line type: the Goa auth boundary, HTTP endpoint handlers, NATS protocol encoding, and health aggregation. This made the message-encoding logic untestable without a full Goa context and blurred the line between HTTP concerns and messaging protocol concerns.

This PR splits that god-type into two focused layers:

1. **`AccessCheckClient`** — owns the NATS protocol (message build, parse, request, health check). No Goa imports.
2. **`AccessService`** — thin Goa adapter: validates JWT, calls the client, maps errors to Goa HTTP types.

---

## Changes

### `internal/service/access_check_client.go` (new)

New `AccessCheckClient` struct that owns everything related to the NATS access-check contract:

| Method | Description |
|--------|-------------|
| `CheckAccess(ctx, principal, resources)` | Builds NATS payload, requests `AccessCheckSubject`, parses newline-delimited response. Replaces `performAccessCheck`. |
| `ReadTuples(ctx, principal, objectType)` | Marshals JSON request, sends to `ReadTuplesSubject`, unmarshals response. Replaces `performReadTuples`. |
| `HealthCheck(ctx)` | Delegates to messaging repo; returns `ErrMessagingRepoNotInit` on nil repo. |
| `buildMessage` (private) | Constructs `object#relation@user:principal` payload. Replaces `buildAccessCheckMessage`. |
| `parseResponse` (private) | Validates and splits the plaintext NATS reply. Replaces `parseAccessCheckResponse`. |

`AccessCheckClient` has **zero Goa imports** — its entire dependency surface is `contracts.MessagingRepository` and `pkg/constants`. It can be unit-tested with only a mock messaging repo.

### `internal/service/access_service.go` (updated)

`AccessService` is now a thin Goa adapter:

- Holds `authRepo` and `client *AccessCheckClient`. The messaging repo is no longer a direct field.
- Two new **package-level helpers** remove the duplicated prelude that previously appeared in both `CheckAccess` and `MyGrants`:
  - `claimsFromContext(ctx)` — extracts `HeimdallClaims` from the request context
  - `requireAPIVersion(version)` — validates the API version string
- `CheckAccess` and `MyGrants` call the helpers then delegate NATS work to the client.
- `Readyz` delegates the messaging health check to `client.HealthCheck(ctx)` instead of an inline nil-check.
- All Goa error mapping (`MakeBadRequest`, `MakeUnauthorized`, `MakeServiceUnavailable`, etc.) stays here.

`NewAccessService(authRepo, messagingRepo)` signature is **unchanged** — no callers needed updating.

### `internal/service/access_check_client_test.go` (new)

Tests for `AccessCheckClient` in isolation, with zero Goa imports:

- `CheckAccess`: empty principal, empty resources, NATS failure, unexpected response (space in first 20 bytes), correct subject routing
- `ReadTuples`: success path, nil-results normalization, NATS failure, unmarshal failure, FGA backend error
- `HealthCheck`: nil repo returns `ErrMessagingRepoNotInit`; healthy repo returns nil
- `buildMessage` table test: empty resources, single, multiple, mixed-empty, all-empty
- `parseResponse` table test: valid lines, empty, empty lines, space-containing error response

### `internal/service/access_service_test.go` (updated)

- Removed tests that exercised methods now on `AccessCheckClient` (`TestPerformAccessCheck_*`, `TestPerformReadTuples_*`, `TestBuildAccessCheckMessage`, `TestParseAccessCheckResponse`) — coverage is carried by `access_check_client_test.go`.
- Service tests now focus on Goa adapter concerns: JWT validation, version gating, claims extraction, Goa error type mapping, health delegation.
- Mock types (`mockAuthRepository`, `mockMessagingRepository`) remain here as they are shared within the package by both test files.

### `internal/service/access_service_bench_test.go` (updated)

Benchmarks updated to target `AccessCheckClient` directly:
- `BenchmarkBuildMessage` (was `BenchmarkBuildAccessCheckMessage`)
- `BenchmarkParseResponse` (was `BenchmarkParseAccessCheckResponse`)
- `BenchmarkCheckAccess` (was `BenchmarkPerformAccessCheck`)

---

## What did NOT change

- **HTTP contract**: request/response shapes, error codes, status codes — all identical
- **NATS subjects**: `AccessCheckSubject` and `ReadTuplesSubject` — unchanged constants
- **Message format**: plaintext newline-separated for access-check; JSON for read-tuples
- **`NewAccessService` signature**: `(authRepo, messagingRepo)` — no call-site changes
- **Container, integration tests, and all packages outside `internal/service/`** — zero modifications

---

## Test results

```
ok  github.com/linuxfoundation/lfx-v2-access-check/internal/container          coverage: 57.9%
ok  github.com/linuxfoundation/lfx-v2-access-check/internal/infrastructure/auth  coverage: 50.0%
ok  github.com/linuxfoundation/lfx-v2-access-check/internal/infrastructure/config coverage: 85.7%
ok  github.com/linuxfoundation/lfx-v2-access-check/internal/infrastructure/messaging coverage: 20.6%
ok  github.com/linuxfoundation/lfx-v2-access-check/internal/middleware          coverage: 100.0%
ok  github.com/linuxfoundation/lfx-v2-access-check/internal/service             coverage: 89.2%
ok  github.com/linuxfoundation/lfx-v2-access-check/pkg/log                      coverage: 86.1%
ok  github.com/linuxfoundation/lfx-v2-access-check/pkg/utils                    coverage: 58.3%
ok  github.com/linuxfoundation/lfx-v2-access-check/test/integration             coverage: 66.7%
```

All packages pass with `-race`. Service package coverage: **89.2%**.

---

## Related / follow-on work

See the comment on LFXV2-2983 for the remaining refactoring backlog (Options B–E), all of which are independent and can be picked up in any order:

- **Option B** — One authoritative mock package (`internal/mocks/` consolidation)
- **Option C** — Injectable container for offline unit tests
- **Option D** — Replace auth `HealthCheck` junk-token probe with a real HTTP JWKS probe
- **Option E** — Delete dead constants and fix `plaintext_test.go`

Made with [Cursor](https://cursor.com)

[LFXV2-2983]: https://linuxfoundation.atlassian.net/browse/LFXV2-2983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ